### PR TITLE
Add schema for BigQuery tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,5 @@
     },
     "[python]": {
         "editor.defaultFormatter": "ms-python.autopep8"
-    },
-    "python.formatting.provider": "none"
+    }
 }

--- a/schema/accounts.json
+++ b/schema/accounts.json
@@ -1,0 +1,54 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "userName",
+        "type": "STRING"
+    },
+    {
+        "name": "balance",
+        "type": "STRING"
+    },
+    {
+        "name": "balanceNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nonce",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "shardID",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "developerRewards",
+        "type": "STRING"
+    },
+    {
+        "name": "developerRewardsNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "totalBalanceWithStake",
+        "type": "STRING"
+    },
+    {
+        "name": "totalBalanceWithStakeNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "currentOwner",
+        "type": "STRING"
+    }
+]

--- a/schema/accountsesdt.json
+++ b/schema/accountsesdt.json
@@ -1,0 +1,106 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "balance",
+        "type": "STRING"
+    },
+    {
+        "name": "balanceNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "currentOwner",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "fields": [
+            {
+                "name": "attributes",
+                "type": "STRING"
+            },
+            {
+                "name": "creator",
+                "type": "STRING"
+            },
+            {
+                "name": "hash",
+                "type": "STRING"
+            },
+            {
+                "name": "metadata",
+                "type": "STRING"
+            },
+            {
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "name": "nonEmptyURIs",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "whiteListedStorage",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "royalties",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "tags",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "uris",
+                "mode": "REPEATED",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "identifier",
+        "type": "STRING"
+    },
+    {
+        "name": "properties",
+        "type": "STRING"
+    },
+    {
+        "name": "shardID",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "token",
+        "type": "STRING"
+    },
+    {
+        "name": "tokenNonce",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "type",
+        "type": "STRING"
+    },
+    {
+        "name": "frozen",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "paused",
+        "type": "BOOLEAN"
+    }
+]

--- a/schema/accountsesdthistory.json
+++ b/schema/accountsesdthistory.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "balance",
+        "type": "STRING"
+    },
+    {
+        "name": "identifier",
+        "type": "STRING"
+    },
+    {
+        "name": "isSender",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "isSmartContract",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "shardID",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "token",
+        "type": "STRING"
+    },
+    {
+        "name": "tokenNonce",
+        "type": "FLOAT64"
+    }
+]

--- a/schema/accountshistory.json
+++ b/schema/accountshistory.json
@@ -1,0 +1,30 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "balance",
+        "type": "STRING"
+    },
+    {
+        "name": "isSender",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "isSmartContract",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "shardID",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    }
+]

--- a/schema/blocks.json
+++ b/schema/blocks.json
@@ -1,0 +1,288 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "accumulatedFees",
+        "type": "STRING"
+    },
+    {
+        "name": "developerFees",
+        "type": "STRING"
+    },
+    {
+        "name": "epoch",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "epochStartBlock",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "epochStartInfo",
+        "fields": [
+            {
+                "name": "nodePrice",
+                "type": "STRING"
+            },
+            {
+                "name": "prevEpochStartHash",
+                "type": "STRING"
+            },
+            {
+                "name": "prevEpochStartRound",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "rewardsForProtocolSustainability",
+                "type": "STRING"
+            },
+            {
+                "name": "rewardsPerBlock",
+                "type": "STRING"
+            },
+            {
+                "name": "totalNewlyMinted",
+                "type": "STRING"
+            },
+            {
+                "name": "totalSupply",
+                "type": "STRING"
+            },
+            {
+                "name": "totalToDistribute",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "epochStartShardsData",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "epoch",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "firstPendingMetaBlock",
+                "type": "STRING"
+            },
+            {
+                "name": "headerHash",
+                "type": "STRING"
+            },
+            {
+                "name": "lastFinishedMetaBlock",
+                "type": "STRING"
+            },
+            {
+                "name": "nonce",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "pendingMiniBlockHeaders",
+                "mode": "REPEATED",
+                "fields": [
+                    {
+                        "name": "hash",
+                        "type": "STRING"
+                    },
+                    {
+                        "name": "receiverShard",
+                        "type": "NUMERIC"
+                    },
+                    {
+                        "name": "senderShard",
+                        "type": "NUMERIC"
+                    },
+                    {
+                        "name": "timestamp",
+                        "type": "TIMESTAMP"
+                    },
+                    {
+                        "name": "type",
+                        "type": "STRING"
+                    }
+                ],
+                "type": "RECORD"
+            },
+            {
+                "name": "rootHash",
+                "type": "STRING"
+            },
+            {
+                "name": "round",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "scheduledRootHash",
+                "type": "STRING"
+            },
+            {
+                "name": "shardID",
+                "type": "NUMERIC"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "gasPenalized",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasProvided",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasRefunded",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "maxGasLimit",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "miniBlocksDetails",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "firstProcessedTx",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "lastProcessedTx",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "senderShard",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "receiverShard",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "mbIndex",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "type",
+                "type": "STRING"
+            },
+            {
+                "name": "procType",
+                "type": "STRING"
+            },
+            {
+                "name": "txsHashes",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "executionOrderTxsIndices",
+                "mode": "REPEATED",
+                "type": "NUMERIC"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "miniBlocksHashes",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "nonce",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "notarizedBlocksHashes",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "notarizedTxsCount",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "prevHash",
+        "type": "STRING"
+    },
+    {
+        "name": "proposer",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "pubKeyBitmap",
+        "type": "STRING"
+    },
+    {
+        "name": "round",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "scheduledData",
+        "fields": [
+            {
+                "name": "accumulatedFees",
+                "type": "STRING"
+            },
+            {
+                "name": "developerFees",
+                "type": "STRING"
+            },
+            {
+                "name": "gasProvided",
+                "type": "FLOAT64"
+            },
+            {
+                "name": "gasRefunded",
+                "type": "FLOAT64"
+            },
+            {
+                "name": "penalized",
+                "type": "FLOAT64"
+            },
+            {
+                "name": "rootHash",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "searchOrder",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "shardId",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "size",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "sizeTxs",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "stateRootHash",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "txCount",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "validators",
+        "mode": "REPEATED",
+        "type": "NUMERIC"
+    }
+]

--- a/schema/delegators.json
+++ b/schema/delegators.json
@@ -1,0 +1,49 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "activeStake",
+        "type": "STRING"
+    },
+    {
+        "name": "activeStakeNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "contract",
+        "type": "STRING"
+    },
+    {
+        "name": "unDelegateInfo",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "id",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "type": "TIMESTAMP"
+            },
+            {
+                "name": "value",
+                "type": "STRING"
+            },
+            {
+                "name": "valueNum",
+                "type": "FLOAT64"
+            }
+        ],
+        "type": "RECORD"
+    }
+]

--- a/schema/epochinfo.json
+++ b/schema/epochinfo.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "accumulatedFees",
+        "type": "STRING"
+    },
+    {
+        "name": "developerFees",
+        "type": "STRING"
+    }
+]

--- a/schema/esdts.json
+++ b/schema/esdts.json
@@ -1,0 +1,136 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "currentOwner",
+        "type": "STRING"
+    },
+    {
+        "name": "issuer",
+        "type": "STRING"
+    },
+    {
+        "name": "name",
+        "type": "STRING"
+    },
+    {
+        "name": "numDecimals",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "ownersHistory",
+        "fields": [
+            {
+                "name": "address",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "type": "TIMESTAMP"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "properties",
+        "fields": [
+            {
+                "name": "canAddSpecialRoles",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canBurn",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canChangeOwner",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canCreateMultiShard",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canFreeze",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canMint",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canPause",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canTransferNFTCreateRole",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canUpgrade",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canWipe",
+                "type": "BOOLEAN"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "roles",
+        "fields": [
+            {
+                "name": "ESDTRoleLocalBurn",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleLocalMint",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTAddQuantity",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTAddURI",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTBurn",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTCreate",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTUpdateAttributes",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTTransferRole",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "ticker",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "token",
+        "type": "STRING"
+    },
+    {
+        "name": "type",
+        "type": "STRING"
+    }
+]

--- a/schema/logs.json
+++ b/schema/logs.json
@@ -1,0 +1,46 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "address",
+        "type": "STRING"
+    },
+    {
+        "name": "events",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "address",
+                "type": "STRING"
+            },
+            {
+                "name": "data",
+                "type": "STRING"
+            },
+            {
+                "name": "identifier",
+                "type": "STRING"
+            },
+            {
+                "name": "topics",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "order",
+                "type": "NUMERIC"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "originalTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    }
+]

--- a/schema/miniblocks.json
+++ b/schema/miniblocks.json
@@ -1,0 +1,42 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "procTypeD",
+        "type": "STRING"
+    },
+    {
+        "name": "procTypeS",
+        "type": "STRING"
+    },
+    {
+        "name": "receiverBlockHash",
+        "type": "STRING"
+    },
+    {
+        "name": "receiverShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "reserved",
+        "type": "STRING"
+    },
+    {
+        "name": "senderBlockHash",
+        "type": "STRING"
+    },
+    {
+        "name": "senderShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "type",
+        "type": "STRING"
+    }
+]

--- a/schema/operations.json
+++ b/schema/operations.json
@@ -1,0 +1,195 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "callType",
+        "type": "STRING"
+    },
+    {
+        "name": "canBeIgnored",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "code",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "type": "STRING"
+    },
+    {
+        "name": "esdtValues",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "fee",
+        "type": "STRING"
+    },
+    {
+        "name": "feeNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "function",
+        "type": "STRING"
+    },
+    {
+        "name": "gasLimit",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasPrice",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasUsed",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "hasOperations",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "hasScResults",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "hasLogs",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "initialPaidFee",
+        "type": "STRING"
+    },
+    {
+        "name": "isRelayed",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "isScCall",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "miniBlockHash",
+        "type": "STRING"
+    },
+    {
+        "name": "nonce",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "operation",
+        "type": "STRING"
+    },
+    {
+        "name": "originalSender",
+        "type": "STRING"
+    },
+    {
+        "name": "originalTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "prevTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "receiver",
+        "type": "STRING"
+    },
+    {
+        "name": "receiverShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "receivers",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "receiversShardIDs",
+        "mode": "REPEATED",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "relayedValue",
+        "type": "STRING"
+    },
+    {
+        "name": "relayerAddr",
+        "type": "STRING"
+    },
+    {
+        "name": "returnMessage",
+        "type": "STRING"
+    },
+    {
+        "name": "round",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "searchOrder",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "sender",
+        "type": "STRING"
+    },
+    {
+        "name": "senderShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "senderUserName",
+        "type": "STRING"
+    },
+    {
+        "name": "signature",
+        "type": "STRING"
+    },
+    {
+        "name": "status",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "tokens",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "type",
+        "type": "STRING"
+    },
+    {
+        "name": "value",
+        "type": "STRING"
+    },
+    {
+        "name": "version",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "valueNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "esdtValuesNum",
+        "mode": "REPEATED",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "guardian",
+        "type": "STRING"
+    },
+    {
+        "name": "guardianSignature",
+        "type": "STRING"
+    }
+]

--- a/schema/rating.json
+++ b/schema/rating.json
@@ -1,0 +1,10 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "rating",
+        "type": "FLOAT64"
+    }
+]

--- a/schema/receipts.json
+++ b/schema/receipts.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "type": "STRING"
+    },
+    {
+        "name": "sender",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "txHash",
+        "type": "STRING"
+    },
+    {
+        "name": "value",
+        "type": "STRING"
+    }
+]

--- a/schema/rounds.json
+++ b/schema/rounds.json
@@ -1,0 +1,31 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "blockWasProposed",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "epoch",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "round",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "shardId",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "signersIndexes",
+        "mode": "REPEATED",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    }
+]

--- a/schema/scdeploys.json
+++ b/schema/scdeploys.json
@@ -1,0 +1,37 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "deployTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "deployer",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "upgrades",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "timestamp",
+                "type": "TIMESTAMP"
+            },
+            {
+                "name": "upgradeTxHash",
+                "type": "STRING"
+            },
+            {
+                "name": "upgrader",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    }
+]

--- a/schema/scresults.json
+++ b/schema/scresults.json
@@ -1,0 +1,127 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "callType",
+        "type": "STRING"
+    },
+    {
+        "name": "code",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "type": "STRING"
+    },
+    {
+        "name": "esdtValues",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "function",
+        "type": "STRING"
+    },
+    {
+        "name": "gasLimit",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasPrice",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "hasOperations",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "hasLogs",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "miniBlockHash",
+        "type": "STRING"
+    },
+    {
+        "name": "nonce",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "operation",
+        "type": "STRING"
+    },
+    {
+        "name": "originalSender",
+        "type": "STRING"
+    },
+    {
+        "name": "originalTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "prevTxHash",
+        "type": "STRING"
+    },
+    {
+        "name": "receiver",
+        "type": "STRING"
+    },
+    {
+        "name": "receiverShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "receivers",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "receiversShardIDs",
+        "mode": "REPEATED",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "relayedValue",
+        "type": "STRING"
+    },
+    {
+        "name": "relayerAddr",
+        "type": "STRING"
+    },
+    {
+        "name": "returnMessage",
+        "type": "STRING"
+    },
+    {
+        "name": "sender",
+        "type": "STRING"
+    },
+    {
+        "name": "senderShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "tokens",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "value",
+        "type": "STRING"
+    },
+    {
+        "name": "valueNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "esdtValuesNum",
+        "mode": "REPEATED",
+        "type": "FLOAT64"
+    }
+]

--- a/schema/tags.json
+++ b/schema/tags.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "count",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "tag",
+        "type": "STRING"
+    }
+]

--- a/schema/tokens.json
+++ b/schema/tokens.json
@@ -1,0 +1,294 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "currentOwner",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "fields": [
+            {
+                "name": "attributes",
+                "type": "STRING"
+            },
+            {
+                "name": "creator",
+                "type": "STRING"
+            },
+            {
+                "name": "hash",
+                "type": "STRING"
+            },
+            {
+                "name": "metadata",
+                "type": "STRING"
+            },
+            {
+                "name": "name",
+                "type": "STRING"
+            },
+            {
+                "name": "nonEmptyURIs",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "royalties",
+                "type": "NUMERIC"
+            },
+            {
+                "name": "tags",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "uris",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "whiteListedStorage",
+                "type": "BOOLEAN"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "identifier",
+        "type": "STRING"
+    },
+    {
+        "name": "issuer",
+        "type": "STRING"
+    },
+    {
+        "name": "name",
+        "type": "STRING"
+    },
+    {
+        "name": "nonce",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "numDecimals",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "ownersHistory",
+        "mode": "REPEATED",
+        "fields": [
+            {
+                "name": "address",
+                "type": "STRING"
+            },
+            {
+                "name": "timestamp",
+                "type": "TIMESTAMP"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "properties",
+        "fields": [
+            {
+                "name": "canAddSpecialRoles",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canBurn",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canChangeOwner",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canCreateMultiShard",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canFreeze",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canMint",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canPause",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canTransferNFTCreateRole",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canUpgrade",
+                "type": "BOOLEAN"
+            },
+            {
+                "name": "canWipe",
+                "type": "BOOLEAN"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "roles",
+        "fields": [
+            {
+                "name": "ESDTRoleLocalBurn",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleLocalMint",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTAddQuantity",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTAddURI",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTBurn",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTCreate",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTUpdateAttributes",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTTransferRole",
+                "mode": "REPEATED",
+                "type": "STRING"
+            },
+            {
+                "name": "ESDTRoleNFTCreateMultiShard",
+                "mode": "REPEATED",
+                "type": "STRING"
+            }
+        ],
+        "type": "RECORD"
+    },
+    {
+        "name": "ticker",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "token",
+        "type": "STRING"
+    },
+    {
+        "name": "type",
+        "type": "STRING"
+    },
+    {
+        "name": "frozen",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "paused",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "api_isVerified",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "api_nftCount",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "api_holderCount",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_traitValues",
+        "type": "STRING"
+    },
+    {
+        "name": "nft_scamInfoType",
+        "type": "STRING"
+    },
+    {
+        "name": "nft_scamInfoDescription",
+        "type": "STRING"
+    },
+    {
+        "name": "nft_hasRarity",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "nft_nsfw_mark",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nft_rank_custom",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_custom_ranks_hash",
+        "type": "STRING"
+    },
+    {
+        "name": "nft_score_openRarity",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nft_rank_openRarity",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_score_jaccardDistances",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nft_rank_jaccardDistances",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_score_trait",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nft_rank_trait",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_score_statistical",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "nft_rank_statistical",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "nft_hasRarities",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "nft_hasTraitSummary",
+        "type": "BOOLEAN"
+    }
+]

--- a/schema/transactions.json
+++ b/schema/transactions.json
@@ -1,0 +1,155 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "data",
+        "type": "STRING"
+    },
+    {
+        "name": "esdtValues",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "fee",
+        "type": "STRING"
+    },
+    {
+        "name": "feeNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "function",
+        "type": "STRING"
+    },
+    {
+        "name": "gasLimit",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasPrice",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "gasUsed",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "hasOperations",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "hasLogs",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "hasScResults",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "initialPaidFee",
+        "type": "STRING"
+    },
+    {
+        "name": "isRelayed",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "isScCall",
+        "type": "BOOLEAN"
+    },
+    {
+        "name": "miniBlockHash",
+        "type": "STRING"
+    },
+    {
+        "name": "nonce",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "operation",
+        "type": "STRING"
+    },
+    {
+        "name": "receiver",
+        "type": "STRING"
+    },
+    {
+        "name": "receiverShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "receivers",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "receiversShardIDs",
+        "mode": "REPEATED",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "round",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "searchOrder",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "sender",
+        "type": "STRING"
+    },
+    {
+        "name": "senderShard",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "senderUserName",
+        "type": "STRING"
+    },
+    {
+        "name": "signature",
+        "type": "STRING"
+    },
+    {
+        "name": "status",
+        "type": "STRING"
+    },
+    {
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "name": "tokens",
+        "mode": "REPEATED",
+        "type": "STRING"
+    },
+    {
+        "name": "value",
+        "type": "STRING"
+    },
+    {
+        "name": "version",
+        "type": "NUMERIC"
+    },
+    {
+        "name": "valueNum",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "esdtValuesNum",
+        "mode": "REPEATED",
+        "type": "FLOAT64"
+    },
+    {
+        "name": "guardian",
+        "type": "STRING"
+    },
+    {
+        "name": "guardianSignature",
+        "type": "STRING"
+    }
+]

--- a/schema/validators.json
+++ b/schema/validators.json
@@ -1,0 +1,11 @@
+[
+    {
+        "name": "_id",
+        "type": "STRING"
+    },
+    {
+        "name": "publicKeys",
+        "mode": "REPEATED",
+        "type": "STRING"
+    }
+]


### PR DESCRIPTION
Schema files are derived from:
 - https://github.com/multiversx/mx-chain-tools-go/tree/main/elasticreindexer/cmd/indices-creator/config/noKibana

The script that derives the schema files comes in a following PR.