### PR TITLE
Add tasks planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,33 @@ pip install -r ./requirements-dev.txt --upgrade
 python3 -m multiversxetl generate_schema --input-folder=~/mx-chain-tools-go/elasticreindexer/cmd/indices-creator/config/noKibana/ --output-folder=./schema
 ```
 
+## Quickstart
+
+First, set the following environment variables:
+
+```
+export WORKSPACE=${HOME}/multiversx-etl
+export INDEXER_URL=https://index.multiversx.com:443
+export GCP_PROJECT_ID=...
+export BQ_DATASET=multiversx_mainnet
+export START_TIMESTAMP=1672243200
+```
+
+Then, plan ETL tasks (will add records in a Firestore database):
+
+```
+python3 -m multiversxetl plan_tasks_with_intervals --indexer-url=${INDEXER_URL} \
+    --gcp-project-id=${GCP_PROJECT_ID}  --bq-dataset=${BQ_DATASET} \
+    --start-timestamp=${START_TIMESTAMP}
+
+python3 -m multiversxetl plan_tasks_without_intervals --indexer-url=${INDEXER_URL} \
+    --gcp-project-id=${GCP_PROJECT_ID}  --bq-dataset=${BQ_DATASET}
+```
+
+**Note:** in order to remove all previously planned tasks, run the following commands:
+
+```
+firebase firestore:delete --project=${GCP_PROJECT_ID} --recursive tasks_with_interval
+firebase firestore:delete --project=${GCP_PROJECT_ID} --recursive tasks_without_interval
+```
+

--- a/multiversxetl/cli/plan_tasks.py
+++ b/multiversxetl/cli/plan_tasks.py
@@ -1,0 +1,73 @@
+import datetime
+import logging
+from pprint import pprint
+
+import click
+
+from multiversxetl.planner import (TasksPlanner, TasksWithIntervalStorage,
+                                   TasksWithoutIntervalStorage)
+from multiversxetl.planner.tasks import count_tasks_by_status
+
+SECONDS_IN_MINUTE = 60
+SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
+
+logging.basicConfig(level=logging.INFO)
+
+
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.option("--gcp-project-id", type=str, help="The GCP project ID.")
+def inspect_tasks(gcp_project_id: str):
+    storage = TasksWithIntervalStorage(gcp_project_id)
+    tasks = storage.get_all_tasks()
+    print(f"Tasks with interval: {len(tasks)}")
+    by_extraction_status, by_loading_status = count_tasks_by_status(tasks)
+    print("\tBy extraction status:")
+    pprint(by_extraction_status, indent=4)
+    print("\tBy loading status:")
+    pprint(by_loading_status, indent=4)
+
+    storage = TasksWithoutIntervalStorage(gcp_project_id)
+    tasks = storage.get_all_tasks()
+    print(f"Tasks without interval: {len(tasks)}")
+    by_extraction_status, by_loading_status = count_tasks_by_status(tasks)
+    print("\tBy extraction status:")
+    pprint(by_extraction_status, indent=4)
+    print("\tBy loading status:")
+    pprint(by_loading_status, indent=4)
+
+
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.option("--indexer-url", type=str, help="The indexer URL (Elastic Search instance).")
+@click.option("--gcp-project-id", type=str, help="The GCP project ID.")
+@click.option("--bq-dataset", type=str, required=True, help="The BigQuery dataset (destination).")
+@click.option("--start-timestamp", type=int, help="The start timestamp (e.g. genesis time).")
+@click.option("--end-timestamp", type=int, help="The end timestamp (e.g. a recent one).")
+@click.option("--granularity", type=int, default=SECONDS_IN_DAY, help="Task granularity, in seconds.")
+def plan_tasks_with_intervals(indexer_url: str, gcp_project_id: str, bq_dataset: str, start_timestamp: int, end_timestamp: int, granularity: int):
+    storage = TasksWithIntervalStorage(gcp_project_id)
+    planner = TasksPlanner()
+
+    if not end_timestamp:
+        now = int(datetime.datetime.utcnow().timestamp())
+        end_timestamp = now - 25 * SECONDS_IN_MINUTE
+
+    new_tasks = planner.plan_tasks_with_intervals(
+        indexer_url,
+        bq_dataset,
+        start_timestamp,
+        end_timestamp,
+        granularity
+    )
+
+    storage.add_tasks(new_tasks)
+
+
+@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.option("--indexer-url", type=str, help="The indexer URL (Elastic Search instance).")
+@click.option("--gcp-project-id", type=str, help="The GCP project ID.")
+@click.option("--bq-dataset", type=str, help="The BigQuery dataset (destination).")
+def plan_tasks_without_intervals(indexer_url: str, gcp_project_id: str, bq_dataset: str):
+    storage = TasksWithoutIntervalStorage(gcp_project_id)
+    planner = TasksPlanner()
+    new_tasks = planner.plan_tasks_without_intervals(indexer_url, bq_dataset)
+    storage.add_tasks(new_tasks)

--- a/multiversxetl/cli/plan_tasks.py
+++ b/multiversxetl/cli/plan_tasks.py
@@ -4,12 +4,10 @@ from pprint import pprint
 
 import click
 
+from multiversxetl.constants import SECONDS_IN_DAY, SECONDS_IN_MINUTE
 from multiversxetl.planner import (TasksPlanner, TasksWithIntervalStorage,
                                    TasksWithoutIntervalStorage)
 from multiversxetl.planner.tasks import count_tasks_by_status
-
-SECONDS_IN_MINUTE = 60
-SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
 
 logging.basicConfig(level=logging.INFO)
 

--- a/multiversxetl/cli/plan_tasks.py
+++ b/multiversxetl/cli/plan_tasks.py
@@ -35,7 +35,7 @@ def inspect_tasks(gcp_project_id: str):
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.option("--indexer-url", type=str, help="The indexer URL (Elastic Search instance).")
+@click.option("--indexer-url", type=str, help="The indexer URL (Elasticsearch instance).")
 @click.option("--gcp-project-id", type=str, help="The GCP project ID.")
 @click.option("--bq-dataset", type=str, required=True, help="The BigQuery dataset (destination).")
 @click.option("--start-timestamp", type=int, help="The start timestamp (e.g. genesis time).")
@@ -61,7 +61,7 @@ def plan_tasks_with_intervals(indexer_url: str, gcp_project_id: str, bq_dataset:
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
-@click.option("--indexer-url", type=str, help="The indexer URL (Elastic Search instance).")
+@click.option("--indexer-url", type=str, help="The indexer URL (Elasticsearch instance).")
 @click.option("--gcp-project-id", type=str, help="The GCP project ID.")
 @click.option("--bq-dataset", type=str, help="The BigQuery dataset (destination).")
 def plan_tasks_without_intervals(indexer_url: str, gcp_project_id: str, bq_dataset: str):

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,4 +1,4 @@
 SECONDS_IN_MINUTE = 60
 SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
-INDEXES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
-INDEXES_WITHOUT_INTERVALS = set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"])
+INDICES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
+INDICES_WITHOUT_INTERVALS = set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"])

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,0 +1,2 @@
+INDEXES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
+INDEXES_WITHOUT_INTERVALS = set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"])

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,2 +1,4 @@
+SECONDS_IN_MINUTE = 60
+SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
 INDEXES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
 INDEXES_WITHOUT_INTERVALS = set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"])

--- a/multiversxetl/errors.py
+++ b/multiversxetl/errors.py
@@ -1,0 +1,3 @@
+class TransientError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/multiversxetl/planner/__init__.py
+++ b/multiversxetl/planner/__init__.py
@@ -1,0 +1,11 @@
+from multiversxetl.planner.tasks_planner import TasksPlanner
+from multiversxetl.planner.tasks_storage import (TasksStorage,
+                                                 TasksWithIntervalStorage,
+                                                 TasksWithoutIntervalStorage)
+
+__all__ = [
+    "TasksPlanner",
+    "TasksStorage",
+    "TasksWithIntervalStorage",
+    "TasksWithoutIntervalStorage"
+]

--- a/multiversxetl/planner/tasks.py
+++ b/multiversxetl/planner/tasks.py
@@ -1,0 +1,172 @@
+
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class TaskStatus(Enum):
+    PENDING = "pending"
+    STARTED = "started"
+    FINISHED = "finished"
+    FAILED = "failed"
+
+
+class Task:
+    def __init__(self,
+                 id: str,
+                 indexer_url: str,
+                 index_name: str,
+                 bq_dataset: str,
+                 start_timestamp: Optional[int] = None,
+                 end_timestamp: Optional[int] = None):
+        self.id = id
+        self.indexer_url = indexer_url
+        self.index_name = index_name
+        self.bq_dataset = bq_dataset
+        self.start_timestamp = start_timestamp
+        self.end_timestamp = end_timestamp
+
+        self.extraction_status: TaskStatus = TaskStatus.PENDING
+        self.extraction_worker_id: Optional[str] = None
+        self.extraction_outcome: str = ""
+
+        self.loading_status: TaskStatus = TaskStatus.PENDING
+        self.loading_worker_id: Optional[str] = None
+        self.loading_outcome: str = ""
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]):
+        task = cls(
+            id=data["id"],
+            indexer_url=data["indexer_url"],
+            index_name=data["index_name"],
+            bq_dataset=data["bq_dataset"],
+            start_timestamp=data["start_timestamp"],
+            end_timestamp=data["end_timestamp"]
+        )
+
+        task.extraction_status = TaskStatus(data["extraction_status"])
+        task.extraction_worker_id = data["extraction_worker_id"]
+        task.extraction_outcome = data["extraction_outcome"]
+
+        task.loading_status = TaskStatus(data["loading_status"])
+        task.loading_worker_id = data["loading_worker_id"]
+        task.loading_outcome = data["loading_outcome"]
+
+        return task
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "indexer_url": self.indexer_url,
+            "index_name": self.index_name,
+            "bq_dataset": self.bq_dataset,
+            "start_timestamp": self.start_timestamp,
+            "end_timestamp": self.end_timestamp,
+
+            "extraction_status": self.extraction_status.value,
+            "extraction_worker_id": self.extraction_worker_id,
+            "extraction_outcome": self.extraction_outcome,
+
+            "loading_status": self.loading_status.value,
+            "loading_worker_id": self.loading_worker_id,
+            "loading_outcome": self.loading_outcome
+        }
+
+    def is_extraction_pending(self):
+        return self.extraction_status == TaskStatus.PENDING
+
+    def is_extraction_finished(self):
+        return self.extraction_status == TaskStatus.FINISHED
+
+    def is_loading_pending(self):
+        return self.loading_status == TaskStatus.PENDING
+
+    def update_on_extraction_started(self, worker_id: str) -> Dict[str, Any]:
+        self.extraction_worker_id = worker_id
+        self.extraction_status = TaskStatus.STARTED
+
+        return {
+            "extraction_worker_id": self.extraction_worker_id,
+            "extraction_status": self.extraction_status.value
+        }
+
+    def update_on_extraction_failure(self, outcome: str) -> Dict[str, Any]:
+        self.extraction_status = TaskStatus.FAILED
+        self.extraction_outcome = outcome
+
+        return {
+            "extraction_status": self.extraction_status.value,
+            "extraction_outcome": self.extraction_outcome
+        }
+
+    def update_on_extraction_finished(self, outcome: str) -> Dict[str, Any]:
+        self.extraction_status = TaskStatus.FINISHED
+        self.extraction_outcome = outcome
+
+        return {
+            "extraction_status": self.extraction_status.value,
+            "extraction_outcome": self.extraction_outcome
+        }
+
+    def update_on_loading_started(self, worker_id: str) -> Dict[str, Any]:
+        self.loading_worker_id = worker_id
+        self.loading_status = TaskStatus.STARTED
+
+        return {
+            "loading_worker_id": self.loading_worker_id,
+            "loading_status": self.loading_status.value
+        }
+
+    def update_on_loading_failure(self, outcome: str) -> Dict[str, Any]:
+        self.loading_status = TaskStatus.FAILED
+        self.loading_outcome = str(outcome)
+
+        return {
+            "loading_status": self.loading_status.value,
+            "loading_outcome": self.loading_outcome
+        }
+
+    def update_on_loading_finished(self, outcome: str) -> Dict[str, Any]:
+        self.loading_status = TaskStatus.FINISHED
+        self.loading_outcome = outcome
+
+        return {
+            "loading_status": self.loading_status.value,
+            "loading_outcome": self.loading_outcome
+        }
+
+    def is_time_bound(self) -> bool:
+        return self.start_timestamp is not None and self.end_timestamp is not None
+
+    def get_pretty_name(self) -> str:
+        return f"{self.index_name}_{self.start_timestamp}_{self.end_timestamp}_{self.id}"
+
+
+def group_tasks_by_status(tasks: List[Task]) -> Tuple[Dict[TaskStatus, List[Task]], Dict[TaskStatus, List[Task]]]:
+    tasks_by_extraction_status: Dict[TaskStatus, List[Task]] = {}
+    tasks_by_loading_status: Dict[TaskStatus, List[Task]] = {}
+
+    for status in TaskStatus:
+        tasks_by_extraction_status[status] = []
+        tasks_by_loading_status[status] = []
+
+    for task in tasks:
+        tasks_by_extraction_status[task.extraction_status].append(task)
+        tasks_by_loading_status[task.loading_status].append(task)
+
+    return tasks_by_extraction_status, tasks_by_loading_status
+
+
+def count_tasks_by_status(tasks: List[Task]) -> Tuple[Dict[TaskStatus, int], Dict[TaskStatus, int]]:
+    tasks_by_extraction_status: Dict[TaskStatus, int] = {}
+    tasks_by_loading_status: Dict[TaskStatus, int] = {}
+
+    for status in TaskStatus:
+        tasks_by_extraction_status[status] = 0
+        tasks_by_loading_status[status] = 0
+
+    for task in tasks:
+        tasks_by_extraction_status[task.extraction_status] += 1
+        tasks_by_loading_status[task.loading_status] += 1
+
+    return tasks_by_extraction_status, tasks_by_loading_status

--- a/multiversxetl/planner/tasks.py
+++ b/multiversxetl/planner/tasks.py
@@ -4,6 +4,16 @@ from typing import Any, Dict, List, Optional, Tuple
 
 
 class TaskStatus(Enum):
+    """
+    Allows us to track the status of a task.
+
+    Ideally (if no errors occur), the status should go from "pending" to "finished", as follows:
+        - "pending extraction" with "pending loading"
+        - "started extraction" with "pending loading"
+        - "finished extraction" with "pending loading"
+        - "finished extraction" with "started loading"
+        - "finished extraction" with "finished loading"
+    """
     PENDING = "pending"
     STARTED = "started"
     FINISHED = "finished"

--- a/multiversxetl/planner/tasks_planner.py
+++ b/multiversxetl/planner/tasks_planner.py
@@ -1,8 +1,8 @@
 import uuid
 from typing import List
 
-from multiversxetl.constants import (INDEXES_WITH_INTERVALS,
-                                     INDEXES_WITHOUT_INTERVALS)
+from multiversxetl.constants import (INDICES_WITH_INTERVALS,
+                                     INDICES_WITHOUT_INTERVALS)
 from multiversxetl.planner.tasks import Task
 
 
@@ -19,13 +19,13 @@ class TasksPlanner:
             granularity_seconds: int
     ) -> List[Task]:
         """
-        Plans ETL tasks for Elastic Search indexes that support time intervals. 
+        Plans ETL tasks for Elasticsearch indices that support time intervals. 
         Each task is time-bounded.
         """
 
         tasks: List[Task] = []
 
-        for index_name in INDEXES_WITH_INTERVALS:
+        for index_name in INDICES_WITH_INTERVALS:
             for start_timestamp in range(initial_start_timestamp, initial_end_timestamp, granularity_seconds):
                 id = self._next_task_id()
                 end_timestamp = min(start_timestamp + granularity_seconds, initial_end_timestamp)
@@ -36,12 +36,12 @@ class TasksPlanner:
 
     def plan_tasks_without_intervals(self, indexer_url: str, bq_dataset: str) -> List[Task]:
         """
-        Plans ETL tasks for Elastic Search indexes that **do not support** time intervals.
+        Plans ETL tasks for Elasticsearch indices that **do not support** time intervals.
         """
 
         tasks: List[Task] = []
 
-        for index_name in INDEXES_WITHOUT_INTERVALS:
+        for index_name in INDICES_WITHOUT_INTERVALS:
             id = self._next_task_id()
             task = Task(id, indexer_url, index_name, bq_dataset)
             tasks.append(task)

--- a/multiversxetl/planner/tasks_planner.py
+++ b/multiversxetl/planner/tasks_planner.py
@@ -1,0 +1,43 @@
+import uuid
+from typing import List
+
+from multiversxetl.planner.tasks import Task
+
+from multiversxetl.constants import INDEXES_WITH_INTERVALS, INDEXES_WITHOUT_INTERVALS
+
+
+class TasksPlanner:
+    def __init__(self):
+        pass
+
+    def plan_tasks_with_intervals(
+            self,
+            indexer_url: str,
+            bq_dataset: str,
+            initial_start_timestamp: int,
+            initial_end_timestamp: int,
+            granularity_seconds: int
+    ) -> List[Task]:
+        tasks: List[Task] = []
+
+        for index_name in INDEXES_WITH_INTERVALS:
+            for start_timestamp in range(initial_start_timestamp, initial_end_timestamp, granularity_seconds):
+                id = self._next_task_id()
+                end_timestamp = start_timestamp + granularity_seconds
+                task = Task(id, indexer_url, index_name, bq_dataset, start_timestamp, end_timestamp)
+                tasks.append(task)
+
+        return tasks
+
+    def plan_tasks_without_intervals(self, indexer_url: str, bq_dataset: str) -> List[Task]:
+        tasks: List[Task] = []
+
+        for index_name in INDEXES_WITHOUT_INTERVALS:
+            id = self._next_task_id()
+            task = Task(id, indexer_url, index_name, bq_dataset)
+            tasks.append(task)
+
+        return tasks
+
+    def _next_task_id(self, ) -> str:
+        return uuid.uuid4().hex

--- a/multiversxetl/planner/tasks_planner.py
+++ b/multiversxetl/planner/tasks_planner.py
@@ -18,6 +18,11 @@ class TasksPlanner:
             initial_end_timestamp: int,
             granularity_seconds: int
     ) -> List[Task]:
+        """
+        Plans ETL tasks for Elastic Search indexes that support time intervals. 
+        Each task is time-bounded.
+        """
+
         tasks: List[Task] = []
 
         for index_name in INDEXES_WITH_INTERVALS:
@@ -30,6 +35,10 @@ class TasksPlanner:
         return tasks
 
     def plan_tasks_without_intervals(self, indexer_url: str, bq_dataset: str) -> List[Task]:
+        """
+        Plans ETL tasks for Elastic Search indexes that **do not support** time intervals.
+        """
+
         tasks: List[Task] = []
 
         for index_name in INDEXES_WITHOUT_INTERVALS:

--- a/multiversxetl/planner/tasks_planner.py
+++ b/multiversxetl/planner/tasks_planner.py
@@ -1,9 +1,9 @@
 import uuid
 from typing import List
 
+from multiversxetl.constants import (INDEXES_WITH_INTERVALS,
+                                     INDEXES_WITHOUT_INTERVALS)
 from multiversxetl.planner.tasks import Task
-
-from multiversxetl.constants import INDEXES_WITH_INTERVALS, INDEXES_WITHOUT_INTERVALS
 
 
 class TasksPlanner:
@@ -23,7 +23,7 @@ class TasksPlanner:
         for index_name in INDEXES_WITH_INTERVALS:
             for start_timestamp in range(initial_start_timestamp, initial_end_timestamp, granularity_seconds):
                 id = self._next_task_id()
-                end_timestamp = start_timestamp + granularity_seconds
+                end_timestamp = min(start_timestamp + granularity_seconds, initial_end_timestamp)
                 task = Task(id, indexer_url, index_name, bq_dataset, start_timestamp, end_timestamp)
                 tasks.append(task)
 

--- a/multiversxetl/planner/tasks_planner_test.py
+++ b/multiversxetl/planner/tasks_planner_test.py
@@ -1,5 +1,5 @@
-from multiversxetl.constants import (INDEXES_WITH_INTERVALS,
-                                     INDEXES_WITHOUT_INTERVALS, SECONDS_IN_DAY)
+from multiversxetl.constants import (INDICES_WITH_INTERVALS,
+                                     INDICES_WITHOUT_INTERVALS, SECONDS_IN_DAY)
 from multiversxetl.planner.tasks import TaskStatus
 from multiversxetl.planner.tasks_planner import TasksPlanner
 
@@ -8,7 +8,7 @@ def test_plan_tasks_with_intervals_with_trivial_intervals():
     planner = TasksPlanner()
     tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", 0, 1, 1)
 
-    assert len(tasks) == len(INDEXES_WITH_INTERVALS)
+    assert len(tasks) == len(INDICES_WITH_INTERVALS)
     assert all([task.indexer_url == "https://example.com" for task in tasks])
     assert all([task.bq_dataset == "foobar" for task in tasks])
     assert all([task.start_timestamp == 0 for task in tasks])
@@ -25,7 +25,7 @@ def test_plan_tasks_with_intervals_with_day_intervals():
     num_expected_intervals = int((end_time - start_time) / SECONDS_IN_DAY) + 1
     tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", start_time, end_time, SECONDS_IN_DAY)
 
-    for index_name in INDEXES_WITH_INTERVALS:
+    for index_name in INDICES_WITH_INTERVALS:
         tasks_of_index = [task for task in tasks if task.index_name == index_name]
 
         assert len(tasks_of_index) == num_expected_intervals
@@ -40,7 +40,7 @@ def test_plan_tasks_with_intervals_without_intervals():
     planner = TasksPlanner()
     tasks = planner.plan_tasks_without_intervals("https://example.com", "foobar")
 
-    assert len(tasks) == len(INDEXES_WITHOUT_INTERVALS)
+    assert len(tasks) == len(INDICES_WITHOUT_INTERVALS)
     assert all([task.indexer_url == "https://example.com" for task in tasks])
     assert all([task.bq_dataset == "foobar" for task in tasks])
     assert all([task.start_timestamp == None for task in tasks])

--- a/multiversxetl/planner/tasks_planner_test.py
+++ b/multiversxetl/planner/tasks_planner_test.py
@@ -1,0 +1,49 @@
+from multiversxetl.constants import (INDEXES_WITH_INTERVALS,
+                                     INDEXES_WITHOUT_INTERVALS, SECONDS_IN_DAY)
+from multiversxetl.planner.tasks import TaskStatus
+from multiversxetl.planner.tasks_planner import TasksPlanner
+
+
+def test_plan_tasks_with_intervals_with_trivial_intervals():
+    planner = TasksPlanner()
+    tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", 0, 1, 1)
+
+    assert len(tasks) == len(INDEXES_WITH_INTERVALS)
+    assert all([task.indexer_url == "https://example.com" for task in tasks])
+    assert all([task.bq_dataset == "foobar" for task in tasks])
+    assert all([task.start_timestamp == 0 for task in tasks])
+    assert all([task.end_timestamp == 1 for task in tasks])
+    assert all([task.extraction_status == TaskStatus.PENDING for task in tasks])
+    assert all([task.loading_status == TaskStatus.PENDING for task in tasks])
+
+
+def test_plan_tasks_with_intervals_with_day_intervals():
+    planner = TasksPlanner()
+
+    start_time = 1596117600
+    end_time = 1687508546
+    num_expected_intervals = int((end_time - start_time) / SECONDS_IN_DAY) + 1
+    tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", start_time, end_time, SECONDS_IN_DAY)
+
+    for index_name in INDEXES_WITH_INTERVALS:
+        tasks_of_index = [task for task in tasks if task.index_name == index_name]
+
+        assert len(tasks_of_index) == num_expected_intervals
+        assert tasks_of_index[0].start_timestamp == start_time
+        assert tasks_of_index[-1].end_timestamp == end_time
+
+        for i in range(len(tasks_of_index) - 1):
+            assert tasks_of_index[i].end_timestamp == tasks_of_index[i + 1].start_timestamp
+
+
+def test_plan_tasks_with_intervals_without_intervals():
+    planner = TasksPlanner()
+    tasks = planner.plan_tasks_without_intervals("https://example.com", "foobar")
+
+    assert len(tasks) == len(INDEXES_WITHOUT_INTERVALS)
+    assert all([task.indexer_url == "https://example.com" for task in tasks])
+    assert all([task.bq_dataset == "foobar" for task in tasks])
+    assert all([task.start_timestamp == None for task in tasks])
+    assert all([task.end_timestamp == None for task in tasks])
+    assert all([task.extraction_status == TaskStatus.PENDING for task in tasks])
+    assert all([task.loading_status == TaskStatus.PENDING for task in tasks])

--- a/multiversxetl/planner/tasks_storage.py
+++ b/multiversxetl/planner/tasks_storage.py
@@ -1,0 +1,186 @@
+from typing import Any, Callable, List, Optional
+
+from google.cloud import firestore
+from google.cloud.firestore import transactional  # type: ignore
+from google.cloud.firestore import CollectionReference
+
+from multiversxetl.planner.tasks import Task, TaskStatus
+
+from multiversxetl.errors import TransientError
+
+CHUNK_SIZE = 100
+
+
+class TasksStorage:
+    def __init__(self, project_id: str, collection: str):
+        self.db = firestore.Client(project=project_id)
+        self.collection = collection
+
+    def get_all_tasks(self) -> List[Task]:
+        snapshots = self.db.collection(self.collection).stream()
+        tasks: List[Task] = []
+
+        for snapshot in snapshots:
+            snapshot_dict = snapshot.to_dict()
+            assert snapshot_dict is not None
+            task = Task.from_dict(snapshot_dict)
+            tasks.append(task)
+
+        return tasks
+
+    def add_tasks(self, tasks: List[Task]):
+        for tasks_chunk in split_to_chunks(tasks, CHUNK_SIZE):
+            batch: Any = self.db.batch()  # type: ignore
+
+            for task in tasks_chunk:
+                task_ref = self.db.collection(self.collection).document(task.id)
+                batch.set(task_ref, task.to_dict())
+
+            batch.commit()
+
+    def take_any_extract_task(self,
+                              worker_id: str,
+                              index_name: Optional[str]) -> Optional[Task]:
+        transaction: Any = self.db.transaction()  # type: ignore
+        collection = self.db.collection(self.collection)
+        task = _transactional_pessimistic_take_any_extraction_task(transaction, collection, worker_id, index_name)
+        return task
+
+    def take_any_load_task(self,
+                           worker_id: str,
+                           index_name: Optional[str]) -> Optional[Task]:
+        transaction: Any = self.db.transaction()  # type: ignore
+        collection = self.db.collection(self.collection)
+        task = _transactional_pessimistic_take_any_loading_task(transaction, collection, worker_id, index_name)
+        return task
+
+    def update_task(self, task_id: str, update_func: Callable[[Task], Any]) -> Task:
+        # We do not use a transaction, since, generally speaking,
+        # we do not expect concurrent updates of the same task (once assigned to a worker).
+        task_ref: Any = self.db.collection(self.collection).document(task_id)
+        snapshot = task_ref.get()
+        data = snapshot.to_dict()
+        assert data is not None
+
+        task = Task.from_dict(data)
+        partial_update = update_func(task)
+        task_ref.update(partial_update)
+        return task
+
+
+class TasksWithIntervalStorage(TasksStorage):
+    def __init__(self, project_id: str):
+        super().__init__(project_id, "tasks_with_interval")
+
+
+class TasksWithoutIntervalStorage(TasksStorage):
+    def __init__(self, project_id: str):
+        super().__init__(project_id, "tasks_without_interval")
+
+
+def _transactional_pessimistic_take_any_extraction_task(
+        transaction: Any,
+        collection: CollectionReference,
+        worker_id: str,
+        index_name: Optional[str]
+) -> Optional[Task]:
+    try:
+        return _transactional_take_any_extraction_task(transaction, collection, worker_id, index_name)
+    except Exception as error:
+        if _is_transient_error(error):
+            raise TransientError(str(error)) from error
+        raise
+
+
+@transactional
+def _transactional_take_any_extraction_task(
+        transaction: Any,
+        collection: CollectionReference,
+        worker_id: str,
+        index_name: Optional[str]
+) -> Optional[Task]:
+    extraction_is_pending_or_failed = ("extraction_status", "in", [TaskStatus.PENDING.value, TaskStatus.FAILED.value])
+    index_name_is = ("index_name", "==", index_name)
+
+    query = collection.where(*extraction_is_pending_or_failed)  # type: ignore
+    if index_name:
+        query = query.where(*index_name_is)  # type: ignore
+
+    pending_tasks = query.limit(1).stream(transaction=transaction)  # type: ignore
+    snapshot = next(pending_tasks, None)
+
+    if not snapshot:
+        return None
+
+    data = snapshot.to_dict()
+    assert data is not None
+
+    task = Task.from_dict(data)
+    transaction.update(snapshot.reference, task.update_on_extraction_started(worker_id))
+    return task
+
+
+def _transactional_pessimistic_take_any_loading_task(
+        transaction: Any,
+        collection: CollectionReference,
+        worker_id: str,
+        index_name: Optional[str]
+) -> Optional[Task]:
+    try:
+        return _transactional_take_any_loading_task(transaction, collection, worker_id, index_name)
+    except Exception as error:
+        if _is_transient_error(error):
+            raise TransientError(str(error)) from error
+        raise
+
+
+@transactional
+def _transactional_take_any_loading_task(
+    transaction: Any,
+    collection: CollectionReference,
+    worker_id: str,
+    index_name: Optional[str]
+) -> Optional[Task]:
+    extraction_is_finished = ("extraction_status", "==", TaskStatus.FINISHED.value)
+    loading_is_pending_or_failed = ("loading_status", "in", [TaskStatus.PENDING.value, TaskStatus.FAILED.value])
+    index_name_is = ("index_name", "==", index_name)
+
+    query = collection.where(*extraction_is_finished).where(*loading_is_pending_or_failed)  # type: ignore
+    if index_name:
+        query = query.where(*index_name_is)  # type: ignore
+
+    pending_tasks = query.limit(1).stream()  # type: ignore
+    snapshot = next(pending_tasks, None)
+
+    if not snapshot:
+        return None
+
+    data = snapshot.to_dict()
+    assert data is not None
+
+    task = Task.from_dict(data)
+    transaction.update(snapshot.reference, task.update_on_loading_started(worker_id))
+    return task
+
+
+def _is_transient_error(error: Exception) -> bool:
+    serialized = str(error).lower()
+
+    if "please try again" in serialized:
+        return True
+    if "aborted due to cross-transaction contention" in serialized:
+        return True
+    if "failed to commit transaction" in serialized:
+        return True
+
+    return False
+
+
+def split_to_chunks(items: List[Any], chunk_size: int) -> List[List[Any]]:
+    chunks: List[List[Any]] = []
+
+    for i in range(0, len(items), chunk_size):
+        chunk = items[i: i + chunk_size]
+        chunks.append(chunk)
+
+    return chunks

--- a/multiversxetl/planner/tasks_storage_test.py
+++ b/multiversxetl/planner/tasks_storage_test.py
@@ -1,0 +1,63 @@
+# pyright: reportPrivateUsage=false
+
+import concurrent.futures
+import os
+from typing import Any, List
+
+import pytest
+
+from multiversxetl.errors import TransientError
+from multiversxetl.planner.tasks import Task
+from multiversxetl.planner.tasks_storage import (TasksStorage,
+                                                 _is_transient_error,
+                                                 _split_to_chunks)
+
+
+def test_is_transient_error():
+    assert _is_transient_error(Exception("Please try again"))
+    assert _is_transient_error(Exception("Aborted due to cross-transaction contention"))
+    assert _is_transient_error(Exception("Failed to commit transaction"))
+    assert not _is_transient_error(Exception("Some error"))
+
+
+def test_split_to_chunks():
+    assert _split_to_chunks([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+    assert _split_to_chunks([1, 2, 3, 4, 5], 3) == [[1, 2, 3], [4, 5]]
+    assert _split_to_chunks([1, 2, 3, 4, 5], 5) == [[1, 2, 3, 4, 5]]
+
+
+@pytest.mark.integration
+def test_add_tasks_then_do_concurrent_take_any_extract_task():
+    project_id: str = os.environ.get("GCP_PROJECT_ID", "")
+    assert project_id, "GCP_PROJECT_ID env var is not set"
+    collection_name = test_add_tasks_then_do_concurrent_take_any_extract_task.__name__
+
+    num_tasks = 64
+    num_workers = 4
+    num_tasks_done = 0
+
+    storage = TasksStorage(project_id, collection_name)
+
+    dummy_tasks: List[Task] = [Task(str(i), "", "", "", 0, 0) for i in range(0, num_tasks)]
+    storage.add_tasks(dummy_tasks)
+
+    while num_tasks_done != num_tasks:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+            future_take: Any = {executor.submit(storage.take_any_extract_task, "worker", None): _ for _ in range(num_tasks)}
+
+            for future in concurrent.futures.as_completed(future_take):
+                try:
+                    task = future.result()
+
+                    if task is None:
+                        # No more tasks to take
+                        pass
+                    else:
+                        storage.update_task(task.id, lambda t: t.update_on_extraction_finished(""))
+                        num_tasks_done += 1
+                except TransientError:
+                    # Transient errors are acceptable
+                    pass
+
+    # Cleanup
+    storage.delete_all_tasks()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: marks tests as being integration tests (deselect with '-m "not integration"')


### PR DESCRIPTION
Added `TasksPlanner` component (along with unit and integration tests).
 
This component is responsible with splitting the **long ETL task** of _copying Elastic Search indexes_ (from a public MultiversX indexer instance) into **many, smaller ETL tasks**. The tasks produced by `TasksPlanner` are saved in a Google Firestore collection, to be taken and resolved / completed at a later time (by separate worker processes).