### PR TITLE
Add load job and transform job

### DIFF
--- a/multiversxetl/jobs/extract_job_test.py
+++ b/multiversxetl/jobs/extract_job_test.py
@@ -32,7 +32,7 @@ class IndexerMock:
 
 class FileStorageMock:
     def get_extracted_path(self, task_pretty_name: str) -> Path:
-        return Path(__file__).parent / f"extracted_{task_pretty_name}.json"
+        return Path(__file__).parent.parent / "testdata" / f"extracted_{task_pretty_name}.json"
 
 
 def test_run_task_with_interval():

--- a/multiversxetl/jobs/load_job.py
+++ b/multiversxetl/jobs/load_job.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+from google.cloud import bigquery
+
+
+class IFileStorage(Protocol):
+    def get_load_path(self, task_pretty_name: str) -> Path: ...
+
+
+class ITask(Protocol):
+    @property
+    def index_name(self) -> str: ...
+    @property
+    def bq_dataset(self) -> str: ...
+    def is_time_bound(self) -> bool: ...
+    @property
+    def start_timestamp(self) -> Optional[int]: ...
+    @property
+    def end_timestamp(self) -> Optional[int]: ...
+    def get_pretty_name(self) -> str: ...
+
+
+class LoadJob:
+    def __init__(self,
+                 gcp_project_id: str,
+                 file_storage: IFileStorage,
+                 task: ITask,
+                 schema_folder: Path) -> None:
+        self.file_storage = file_storage
+        self.task = task
+        self.schema_folder = schema_folder
+        self.bigquery_client = bigquery.Client(project=gcp_project_id)
+
+    def run(self) -> None:
+        table_id = self._get_table_id()
+        file_path = self.file_storage.get_load_path(self.task.get_pretty_name())
+        job_config = self._prepare_job_config()
+
+        with open(file_path, "rb") as source_file:
+            job = self.bigquery_client.load_table_from_file(source_file, table_id, job_config=job_config)
+
+        # Waits for the job to complete.
+        job.result()
+
+        table: Any = self.bigquery_client.get_table(table_id)
+        print(
+            "Loaded {} rows and {} columns to {}".format(
+                table.num_rows, len(table.schema), table_id
+            )
+        )
+
+    def _get_table_id(self) -> str:
+        return f"{self.task.bq_dataset}.{self.task.index_name}"
+
+    def _prepare_job_config(self) -> bigquery.LoadJobConfig:
+        schema_path = self.schema_folder / f"{self.task.index_name}.json"
+        schema = self.bigquery_client.schema_from_json(schema_path)
+        write_disposition = self._get_write_disposition()
+
+        return bigquery.LoadJobConfig(
+            schema=schema,
+            source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
+            write_disposition=write_disposition
+        )
+
+    def _get_write_disposition(self) -> str:
+        if self.task.is_time_bound():
+            return "WRITE_APPEND"
+        return "WRITE_TRUNCATE"

--- a/multiversxetl/jobs/load_job.py
+++ b/multiversxetl/jobs/load_job.py
@@ -3,6 +3,9 @@ from typing import Any, Optional, Protocol
 
 from google.cloud import bigquery
 
+WRITE_DISPOSITION_APPEND = "WRITE_APPEND"
+WRITE_DISPOSITION_TRUNCATE = "WRITE_TRUNCATE"
+
 
 class IFileStorage(Protocol):
     def get_load_path(self, task_pretty_name: str) -> Path: ...
@@ -66,5 +69,5 @@ class LoadJob:
 
     def _get_write_disposition(self) -> str:
         if self.task.is_time_bound():
-            return "WRITE_APPEND"
-        return "WRITE_TRUNCATE"
+            return WRITE_DISPOSITION_APPEND
+        return WRITE_DISPOSITION_TRUNCATE

--- a/multiversxetl/jobs/load_job_test.py
+++ b/multiversxetl/jobs/load_job_test.py
@@ -1,0 +1,42 @@
+# pyright: reportPrivateUsage=false
+
+from pathlib import Path
+from typing import Any
+
+from multiversxetl.jobs.load_job import LoadJob
+from multiversxetl.planner.tasks import Task
+
+schema_folder = Path(__file__).parent.parent.parent / "schema"
+
+
+class FileStorageMock:
+    def get_load_path(self, task_pretty_name: str) -> Path:
+        return Path(__file__).parent / f"transformed_{task_pretty_name}.json"
+
+
+def test_get_table_id():
+    file_storage = FileStorageMock()
+    task = Task("test", "", "test_index_name", "test_dataset", 0, 1)
+    job = LoadJob("test-project", file_storage, task, schema_folder)
+
+    assert job._get_table_id() == "test_dataset.test_index_name"
+
+
+def test_prepare_job_config():
+    file_storage = FileStorageMock()
+
+    task = Task("test", "", "transactions", "test_dataset", 0, 1)
+    job = LoadJob("test-project", file_storage, task, schema_folder)
+    job_config: Any = job._prepare_job_config()
+
+    assert job_config.write_disposition == "WRITE_APPEND"
+    assert job_config.source_format == "NEWLINE_DELIMITED_JSON"
+    assert len(job_config.schema) == 38
+
+    task = Task("test", "", "accounts", "test_dataset")
+    job = LoadJob("test-project", file_storage, task, schema_folder)
+    job_config: Any = job._prepare_job_config()
+
+    assert job_config.write_disposition == "WRITE_TRUNCATE"
+    assert job_config.source_format == "NEWLINE_DELIMITED_JSON"
+    assert len(job_config.schema) == 13

--- a/multiversxetl/jobs/load_job_test.py
+++ b/multiversxetl/jobs/load_job_test.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 from typing import Any
 
-from multiversxetl.jobs.load_job import LoadJob
+from google.cloud import bigquery
+
+from multiversxetl.jobs.load_job import (WRITE_DISPOSITION_APPEND,
+                                         WRITE_DISPOSITION_TRUNCATE, LoadJob)
 from multiversxetl.planner.tasks import Task
 
 schema_folder = Path(__file__).parent.parent.parent / "schema"
@@ -29,14 +32,14 @@ def test_prepare_job_config():
     job = LoadJob("test-project", file_storage, task, schema_folder)
     job_config: Any = job._prepare_job_config()
 
-    assert job_config.write_disposition == "WRITE_APPEND"
-    assert job_config.source_format == "NEWLINE_DELIMITED_JSON"
+    assert job_config.write_disposition == WRITE_DISPOSITION_APPEND
+    assert job_config.source_format == bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
     assert len(job_config.schema) == 38
 
     task = Task("test", "", "accounts", "test_dataset")
     job = LoadJob("test-project", file_storage, task, schema_folder)
     job_config: Any = job._prepare_job_config()
 
-    assert job_config.write_disposition == "WRITE_TRUNCATE"
-    assert job_config.source_format == "NEWLINE_DELIMITED_JSON"
+    assert job_config.write_disposition == WRITE_DISPOSITION_TRUNCATE
+    assert job_config.source_format == bigquery.SourceFormat.NEWLINE_DELIMITED_JSON
     assert len(job_config.schema) == 13

--- a/multiversxetl/jobs/transform_job.py
+++ b/multiversxetl/jobs/transform_job.py
@@ -52,7 +52,7 @@ class Transformer:
 
 class BlocksTransformer(Transformer):
     def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        del data["pubKeyBitmap"]
+        data.pop("pubKeyBitmap", None)
         return data
 
 

--- a/multiversxetl/jobs/transform_job.py
+++ b/multiversxetl/jobs/transform_job.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Protocol
+
+
+class IFileStorage(Protocol):
+    def get_extracted_path(self, task_pretty_name: str) -> Path: ...
+    def get_transformed_path(self, task_pretty_name: str) -> Path: ...
+
+
+class ITask(Protocol):
+    @property
+    def index_name(self) -> str: ...
+    def get_pretty_name(self) -> str: ...
+
+
+class TransformJob:
+    def __init__(self, file_storage: IFileStorage, task: ITask) -> None:
+        self.file_storage = file_storage
+        self.task = task
+        self.transformers: Dict[str, Transformer] = dict()
+
+        self._register_transformer("blocks", BlocksTransformer())
+        self._register_transformer("tokens", TokensTransformer())
+        self._register_transformer("logs", LogsTransformer())
+
+    def _register_transformer(self, index_name: str, transformer: 'Transformer') -> None:
+        self.transformers[index_name] = transformer
+
+    def run(self) -> None:
+        transformer = self.transformers.get(self.task.index_name, Transformer())
+        input_filename = self.file_storage.get_extracted_path(self.task.get_pretty_name())
+        output_filename = self.file_storage.get_transformed_path(self.task.get_pretty_name())
+
+        with open(input_filename) as file:
+            with open(output_filename, "w") as output_file:
+                for line in file:
+                    transformed_line = transformer.transform(line)
+                    output_file.write(transformed_line + "\n")
+
+
+class Transformer:
+    def transform(self, raw_json: str) -> str:
+        data = json.loads(raw_json)
+        data = self._do_transform(data)
+        output = json.dumps(data)
+        return output
+
+    def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        return data
+
+
+class BlocksTransformer(Transformer):
+    def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        del data["pubKeyBitmap"]
+        return data
+
+
+class TokensTransformer(Transformer):
+    def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        data.pop("nft_traitValues", None)
+        data.pop("nft_scamInfoType", None)
+        data.pop("nft_scamInfoDescription", None)
+        return data
+
+
+class LogsTransformer(Transformer):
+    def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        events = data.get("events", []) or []
+
+        for event in events:
+            topics = event.get("topics", []) or []
+            # Replace NULL values with empty strings, since BigQuery does not support NULL values in arrays (mode = REPEATED).
+            event["topics"] = [topic if topic is not None else "" for topic in topics]
+
+        # We've altered the data in-place.
+        return data

--- a/multiversxetl/jobs/transform_job_test.py
+++ b/multiversxetl/jobs/transform_job_test.py
@@ -17,7 +17,7 @@ class FileStorageMock:
 
 class DummyTransformer(Transformer):
     def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        del data["a"]
+        data.pop("a", None)
         return data
 
 

--- a/multiversxetl/jobs/transform_job_test.py
+++ b/multiversxetl/jobs/transform_job_test.py
@@ -1,0 +1,71 @@
+# pyright: reportPrivateUsage=false
+
+from pathlib import Path
+from typing import Any, Dict
+
+from multiversxetl.jobs.transform_job import Transformer, TransformJob
+from multiversxetl.planner.tasks import Task
+
+
+class FileStorageMock:
+    def get_extracted_path(self, task_pretty_name: str) -> Path:
+        return Path(__file__).parent.parent / "testdata" / f"extracted_{task_pretty_name}.txt"
+
+    def get_transformed_path(self, task_pretty_name: str) -> Path:
+        return Path(__file__).parent.parent / "testdata" / f"transformed_{task_pretty_name}.txt"
+
+
+class DummyTransformer(Transformer):
+    def _do_transform(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        del data["a"]
+        return data
+
+
+def test_run_with_noop_transform():
+    file_storage = FileStorageMock()
+    task = Task("test", "test", "foobar", "test", 0, 1)
+
+    input_file = file_storage.get_extracted_path(task.get_pretty_name())
+    output_file = file_storage.get_transformed_path(task.get_pretty_name())
+
+    input_file.write_text("""\
+{"a": 1, "b": 2, "c": 3}
+{"a": 2, "b": 3, "c": 4}
+{"a": 3, "b": 4, "c": 5}
+""")
+
+    job = TransformJob(file_storage, task)
+    job.run()
+
+    assert output_file.read_text() == input_file.read_text()
+
+    input_file.unlink(missing_ok=True)
+    output_file.unlink(missing_ok=True)
+
+
+def test_run_with_proper_transform():
+    file_storage = FileStorageMock()
+    task = Task("test", "test", "foobar", "test", 0, 1)
+
+    input_file = file_storage.get_extracted_path(task.get_pretty_name())
+    output_file = file_storage.get_transformed_path(task.get_pretty_name())
+
+    input_file.write_text("""\
+{"a": 1, "b": 2, "c": 3}
+{"a": 2, "b": 3, "c": 4}
+{"a": 3, "b": 4, "c": 5}
+""")
+
+    job = TransformJob(file_storage, task)
+    job._register_transformer("foobar", DummyTransformer())
+
+    job.run()
+
+    assert output_file.read_text() == """\
+{"b": 2, "c": 3}
+{"b": 3, "c": 4}
+{"b": 4, "c": 5}
+"""
+
+    input_file.unlink(missing_ok=True)
+    output_file.unlink(missing_ok=True)


### PR DESCRIPTION
Implement the `T` and `L` parts of `ETL`.

 - **Transform** - if necessary, alter the JSON data extracted from Elasticsearch.
 - **Load** - load the transform data in a BQ dataset. Each index will get a separate BQ table.

References:
 - https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#loading_json_data_into_a_new_table