### PR TITLE
Allow one to plan ETL tasks for specific ES indices

### DIFF
--- a/multiversxetl/cli/plan_tasks.py
+++ b/multiversxetl/cli/plan_tasks.py
@@ -1,10 +1,13 @@
 import datetime
 import logging
 from pprint import pprint
+from typing import Tuple
 
 import click
 
-from multiversxetl.constants import SECONDS_IN_DAY, SECONDS_IN_MINUTE
+from multiversxetl.constants import (INDICES_WITH_INTERVALS,
+                                     INDICES_WITHOUT_INTERVALS, SECONDS_IN_DAY,
+                                     SECONDS_IN_MINUTE)
 from multiversxetl.planner import (TasksPlanner, TasksWithIntervalStorage,
                                    TasksWithoutIntervalStorage)
 from multiversxetl.planner.tasks import count_tasks_by_status
@@ -38,12 +41,13 @@ def inspect_tasks(gcp_project_id: str):
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option("--indexer-url", type=str, help="The indexer URL (Elasticsearch instance).")
+@click.option("--indices", multiple=True, default=INDICES_WITH_INTERVALS)
 @click.option("--gcp-project-id", type=str, help="The GCP project ID.")
 @click.option("--bq-dataset", type=str, required=True, help="The BigQuery dataset (destination).")
 @click.option("--start-timestamp", type=int, help="The start timestamp (e.g. genesis time).")
 @click.option("--end-timestamp", type=int, help="The end timestamp (e.g. a recent one).")
 @click.option("--granularity", type=int, default=SECONDS_IN_DAY, help="Task granularity, in seconds.")
-def plan_tasks_with_intervals(indexer_url: str, gcp_project_id: str, bq_dataset: str, start_timestamp: int, end_timestamp: int, granularity: int):
+def plan_tasks_with_intervals(indexer_url: str, indices: Tuple[str, ...], gcp_project_id: str, bq_dataset: str, start_timestamp: int, end_timestamp: int, granularity: int):
     storage = TasksWithIntervalStorage(gcp_project_id)
     planner = TasksPlanner()
 
@@ -53,6 +57,7 @@ def plan_tasks_with_intervals(indexer_url: str, gcp_project_id: str, bq_dataset:
 
     new_tasks = planner.plan_tasks_with_intervals(
         indexer_url,
+        list(indices),
         bq_dataset,
         start_timestamp,
         end_timestamp,
@@ -64,10 +69,11 @@ def plan_tasks_with_intervals(indexer_url: str, gcp_project_id: str, bq_dataset:
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))
 @click.option("--indexer-url", type=str, help="The indexer URL (Elasticsearch instance).")
+@click.option("--indices", multiple=True, default=INDICES_WITHOUT_INTERVALS)
 @click.option("--gcp-project-id", type=str, help="The GCP project ID.")
 @click.option("--bq-dataset", type=str, help="The BigQuery dataset (destination).")
-def plan_tasks_without_intervals(indexer_url: str, gcp_project_id: str, bq_dataset: str):
+def plan_tasks_without_intervals(indexer_url: str, indices: Tuple[str, ...], gcp_project_id: str, bq_dataset: str):
     storage = TasksWithoutIntervalStorage(gcp_project_id)
     planner = TasksPlanner()
-    new_tasks = planner.plan_tasks_without_intervals(indexer_url, bq_dataset)
+    new_tasks = planner.plan_tasks_without_intervals(indexer_url, list(indices), bq_dataset)
     storage.add_tasks(new_tasks)

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,4 +1,4 @@
 SECONDS_IN_MINUTE = 60
 SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
 INDICES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
-INDICES_WITHOUT_INTERVALS = set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"])
+INDICES_WITHOUT_INTERVALS = list(set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"]))

--- a/multiversxetl/planner/tasks_planner.py
+++ b/multiversxetl/planner/tasks_planner.py
@@ -1,8 +1,6 @@
 import uuid
 from typing import List
 
-from multiversxetl.constants import (INDICES_WITH_INTERVALS,
-                                     INDICES_WITHOUT_INTERVALS)
 from multiversxetl.planner.tasks import Task
 
 
@@ -13,6 +11,7 @@ class TasksPlanner:
     def plan_tasks_with_intervals(
             self,
             indexer_url: str,
+            indices: List[str],
             bq_dataset: str,
             initial_start_timestamp: int,
             initial_end_timestamp: int,
@@ -25,7 +24,7 @@ class TasksPlanner:
 
         tasks: List[Task] = []
 
-        for index_name in INDICES_WITH_INTERVALS:
+        for index_name in indices:
             for start_timestamp in range(initial_start_timestamp, initial_end_timestamp, granularity_seconds):
                 id = self._next_task_id()
                 end_timestamp = min(start_timestamp + granularity_seconds, initial_end_timestamp)
@@ -34,14 +33,19 @@ class TasksPlanner:
 
         return tasks
 
-    def plan_tasks_without_intervals(self, indexer_url: str, bq_dataset: str) -> List[Task]:
+    def plan_tasks_without_intervals(
+            self,
+            indexer_url: str,
+            indices: List[str],
+            bq_dataset: str
+    ) -> List[Task]:
         """
         Plans ETL tasks for Elasticsearch indices that **do not support** time intervals.
         """
 
         tasks: List[Task] = []
 
-        for index_name in INDICES_WITHOUT_INTERVALS:
+        for index_name in indices:
             id = self._next_task_id()
             task = Task(id, indexer_url, index_name, bq_dataset)
             tasks.append(task)

--- a/multiversxetl/planner/tasks_planner_test.py
+++ b/multiversxetl/planner/tasks_planner_test.py
@@ -6,7 +6,7 @@ from multiversxetl.planner.tasks_planner import TasksPlanner
 
 def test_plan_tasks_with_intervals_with_trivial_intervals():
     planner = TasksPlanner()
-    tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", 0, 1, 1)
+    tasks = planner.plan_tasks_with_intervals("https://example.com", INDICES_WITH_INTERVALS, "foobar", 0, 1, 1)
 
     assert len(tasks) == len(INDICES_WITH_INTERVALS)
     assert all([task.indexer_url == "https://example.com" for task in tasks])
@@ -23,7 +23,7 @@ def test_plan_tasks_with_intervals_with_day_intervals():
     start_time = 1596117600
     end_time = 1687508546
     num_expected_intervals = int((end_time - start_time) / SECONDS_IN_DAY) + 1
-    tasks = planner.plan_tasks_with_intervals("https://example.com", "foobar", start_time, end_time, SECONDS_IN_DAY)
+    tasks = planner.plan_tasks_with_intervals("https://example.com", INDICES_WITH_INTERVALS, "foobar", start_time, end_time, SECONDS_IN_DAY)
 
     for index_name in INDICES_WITH_INTERVALS:
         tasks_of_index = [task for task in tasks if task.index_name == index_name]
@@ -38,7 +38,7 @@ def test_plan_tasks_with_intervals_with_day_intervals():
 
 def test_plan_tasks_with_intervals_without_intervals():
     planner = TasksPlanner()
-    tasks = planner.plan_tasks_without_intervals("https://example.com", "foobar")
+    tasks = planner.plan_tasks_without_intervals("https://example.com", INDICES_WITHOUT_INTERVALS, "foobar")
 
     assert len(tasks) == len(INDICES_WITHOUT_INTERVALS)
     assert all([task.indexer_url == "https://example.com" for task in tasks])


### PR DESCRIPTION
E.g.

```
python3 -m multiversxetl plan-tasks-with-intervals --indexer-url=... \
    --gcp-project-id=... --bq-dataset=... \
    --start-timestamp=... --end-timestamp=... \
    --indices transactions --indices blocks --indices miniblocks
```