### PR TITLE
Make workers multi-threaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ python3 -m multiversxetl inspect-tasks --gcp-project-id=${GCP_PROJECT_ID}
 Then, extract and load the data on _worker_ machines:
 
 ```
-python3 -m multiversxetl extract-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID}
-python3 -m multiversxetl extract-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID}
-python3 -m multiversxetl load-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema
-python3 -m multiversxetl load-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema
+python3 -m multiversxetl extract-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --num-threads=4
+python3 -m multiversxetl extract-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --num-threads=4
+python3 -m multiversxetl load-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema --num-threads=4
+python3 -m multiversxetl load-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema --num-threads=4
 ```
 
 From time to time, you may want to run `inspect-tasks` again to check the progress.

--- a/multiversxetl/cli/work.py
+++ b/multiversxetl/cli/work.py
@@ -207,13 +207,13 @@ def do_any_load_task(
         raise
 
 
-def do_continuously(callable: Callable[[], None], sleep_between_tasks: int, num_threads: int):
+def do_continuously(callable: Callable[[], None], sleep_between_tasks: int, num_threads: int, thread_start_delay: int = 1):
     threads: List[threading.Thread] = []
     should_stop_all_threads = threading.Event()
 
     for i in range(num_threads):
         # Start threads with a small delay between them.
-        time.sleep(i)
+        time.sleep(thread_start_delay)
 
         thread = threading.Thread(
             name=f"Thread-{i}",
@@ -244,6 +244,7 @@ def do_continuously_in_thread(callable: Callable[[], None], sleep_between_tasks:
             should_stop.set()
             raise
 
+        # Other threads may have set the stop flag (e.g. due to an exception).
         if should_stop.is_set():
             break
 


### PR DESCRIPTION
 - Allow one to start more than one thread per worker using `--num-threads=N`.
 - Remove handling of `KeyboardInterrupt` - not very useful, and a bit more complex to adjust in the multi-threaded flow.