### PR TITLE
Check "end-time" when planning tasks. Do not allow a time that is too recent

### DIFF
--- a/multiversxetl/__main__.py
+++ b/multiversxetl/__main__.py
@@ -1,8 +1,14 @@
 import logging
+import sys
 
 from multiversxetl.cli import cli
+from multiversxetl.errors import UsageError
 
 logging.basicConfig(level=logging.INFO, format="[%(threadName)s] [%(levelname)s] [%(module)s]: %(message)s")
 
 if __name__ == "__main__":
-    cli()
+    try:
+        cli()
+    except UsageError as error:
+        logging.error(error)
+        sys.exit(1)

--- a/multiversxetl/cli/plan_tasks.py
+++ b/multiversxetl/cli/plan_tasks.py
@@ -4,9 +4,10 @@ from typing import Tuple
 
 import click
 
-from multiversxetl.constants import (INDICES_WITH_INTERVALS,
-                                     INDICES_WITHOUT_INTERVALS, SECONDS_IN_DAY,
-                                     SECONDS_IN_MINUTE)
+from multiversxetl.constants import (
+    INDICES_WITH_INTERVALS, INDICES_WITHOUT_INTERVALS,
+    MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION, SECONDS_IN_DAY)
+from multiversxetl.errors import UsageError
 from multiversxetl.planner import (TasksPlanner, TasksWithIntervalStorage,
                                    TasksWithoutIntervalStorage)
 from multiversxetl.planner.tasks import count_tasks_by_status
@@ -48,9 +49,7 @@ def plan_tasks_with_intervals(indexer_url: str, indices: Tuple[str, ...], gcp_pr
     storage = TasksWithIntervalStorage(gcp_project_id)
     planner = TasksPlanner()
 
-    if not end_timestamp:
-        now = int(datetime.datetime.utcnow().timestamp())
-        end_timestamp = now - 25 * SECONDS_IN_MINUTE
+    end_timestamp = validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(end_timestamp)
 
     new_tasks = planner.plan_tasks_with_intervals(
         indexer_url,
@@ -62,6 +61,18 @@ def plan_tasks_with_intervals(indexer_url: str, indices: Tuple[str, ...], gcp_pr
     )
 
     storage.add_tasks(new_tasks)
+
+
+def validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(end_timestamp: int):
+    now = int(datetime.datetime.utcnow().timestamp())
+    max_end_timestamp = now - MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION
+
+    if not end_timestamp:
+        end_timestamp = max_end_timestamp
+    elif end_timestamp > max_end_timestamp:
+        raise UsageError(f"End timestamp {end_timestamp} is too recent. It should be at most {max_end_timestamp} (current time - {MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION} seconds).")
+
+    return end_timestamp
 
 
 @click.command(context_settings=dict(help_option_names=["-h", "--help"]))

--- a/multiversxetl/cli/plan_tasks_test.py
+++ b/multiversxetl/cli/plan_tasks_test.py
@@ -1,0 +1,34 @@
+import datetime
+from typing import Any
+
+import pytest
+
+from multiversxetl.cli.plan_tasks import \
+    validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals
+from multiversxetl.constants import \
+    MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION
+
+
+def test_validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(monkeypatch: Any):
+    now = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    max_time = int(now.timestamp()) - MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION
+    assert max_time == 1672529400
+
+    class DummyDatetime:
+        @classmethod
+        def utcnow(cls):
+            return now
+
+    monkeypatch.setattr(datetime, "datetime", DummyDatetime)
+
+    # No time specified
+    timestamp = validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(0)
+    assert timestamp == max_time
+
+    # Good time specified
+    timestamp = validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(max_time - 1)
+    assert timestamp == max_time - 1
+
+    # Bad time specified (too recent)
+    with pytest.raises(Exception, match=f"End timestamp {max_time+1} is too recent. It should be at most {max_time} \\(current time - {MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION} seconds\\)."):
+        validate_and_coalesce_end_timestamp_for_plan_tasks_with_intervals(max_time + 1)

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,4 +1,5 @@
 SECONDS_IN_MINUTE = 60
 SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
+MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION = 30 * SECONDS_IN_MINUTE
 INDICES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
 INDICES_WITHOUT_INTERVALS = list(set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"]))

--- a/multiversxetl/constants.py
+++ b/multiversxetl/constants.py
@@ -1,5 +1,5 @@
 SECONDS_IN_MINUTE = 60
 SECONDS_IN_DAY = 24 * 60 * SECONDS_IN_MINUTE
-MIN_DISTANCE_FROM_CURRENT_TIME_FOR_EXTRACTION = 30 * SECONDS_IN_MINUTE
+MIN_TIME_DELTA_FROM_NOW_FOR_EXTRACTION = 30 * SECONDS_IN_MINUTE
 INDICES_WITH_INTERVALS = ["accountsesdt", "tokens", "blocks", "receipts", "transactions", "miniblocks", "rounds", "accountshistory", "scresults", "accountsesdthistory", "scdeploys", "logs", "operations"]
 INDICES_WITHOUT_INTERVALS = list(set(["accounts", "rating", "validators", "epochinfo", "tags", "delegators"]) - set(["rating", "tags"]))

--- a/multiversxetl/errors.py
+++ b/multiversxetl/errors.py
@@ -1,3 +1,8 @@
 class TransientError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
+
+
+class UsageError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)


### PR DESCRIPTION
At first (this initial implementation of the ETL solution), we'd like to only extract & load blockchain data that is older than a given "time buffer" (e.g. 30 minutes).

**Primary reason:** emphasize that the BQ dataset does not contain real-time data, but should be used for analytical purposes instead. 

**Secondary reasons:**
 - alleviate abnormal network conditions, be more tolerant to erroneous indexing observers 