### PR TITLE
Handle grpc "Corruption detected" errors

### DIFF
--- a/multiversxetl/__main__.py
+++ b/multiversxetl/__main__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 
 from multiversxetl.cli import cli
@@ -7,6 +8,9 @@ from multiversxetl.errors import UsageError
 logging.basicConfig(level=logging.INFO, format="[%(threadName)s] [%(levelname)s] [%(module)s]: %(message)s")
 
 if __name__ == "__main__":
+    # See: https://github.com/grpc/grpc/issues/28557
+    os.environ["GRPC_POLL_STRATEGY"] = "poll"
+
     try:
         cli()
     except UsageError as error:


### PR DESCRIPTION
Example of error, rarely occurring (when interacting with Firestore - concurrent requests etc.):

```
E0706 14:11:07.289186459 3404667 ssl_transport_security_utils.cc:105]  Corruption detected.
E0706 14:11:07.289241545 3404667 ssl_transport_security_utils.cc:61]   error:100003fc:SSL routines:OPENSSL_internal:SSLV3_ALERT_BAD_RECORD_MAC
E0706 14:11:07.289253436 3404667 secure_endpoint.cc:305]               Decryption error: TSI_DATA_CORRUPTED
```

See:
 - https://github.com/grpc/grpc/issues/28557
 - https://stackoverflow.com/questions/58241849/ssl-error-using-multiprocessing-in-python-with-google-cloud-services