### PR TITLE
Add "group" parameter (better organize ETL tasks)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,4 +29,5 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Test with pytest
       run: |
+        export PYTHONPATH=.
         pytest -m "not integration"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    name: Run tests on ${{ matrix.os }}, python ${{ matrix.python-version }}
+    
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    - name: Test with pytest
+      run: |
+        pytest -m "not integration"

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ pip install -r ./requirements.txt --upgrade
 pip install -r ./requirements-dev.txt --upgrade
 ```
 
+## Run the tests
+
+```
+export PYTHONPATH=.
+pytest -m "not integration"
+```
+
 ## Generate schema files
 
 ```

--- a/README.md
+++ b/README.md
@@ -64,3 +64,11 @@ python3 -m multiversxetl load-without-intervals --gcp-project-id=${GCP_PROJECT_I
 ```
 
 From time to time, you may want to run `inspect-tasks` again to check the progress.
+
+## Management (Google Cloud Console)
+
+Below are a few links useful for managing the ETL process. They are only accessible to the MultiversX team.
+
+ - [Firestore dashboard](https://console.cloud.google.com/firestore/databases/-default-/data/panel?project=multiversx-blockchain-etl): inspect and manage the Firestore collections that store the metadata of the ETL tasks.
+ - [BigQuery Workspace](https://console.cloud.google.com/bigquery?project=multiversx-blockchain-etl): inspect and manage the BigQuery datasets and tables.
+ - [Analytics Hub](https://console.cloud.google.com/bigquery/analytics-hub/exchanges?project=multiversx-blockchain-etl): create and publish data listings.

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ python3 -m multiversxetl generate-schema --input-folder=~/mx-chain-tools-go/elas
 First, set the following environment variables:
 
 ```
+export GCP_PROJECT_ID=multiversx-blockchain-etl
+export GROUP=mainnet
 export WORKSPACE=${HOME}/multiversx-etl
 export INDEXER_URL=https://index.multiversx.com:443
-export GCP_PROJECT_ID=multiversx-blockchain-etl
 export BQ_DATASET=mainnet
 export START_TIMESTAMP=1596117600
-export END_TIMESTAMP=1687880000
+export END_TIMESTAMP=1689920000
 ```
 
 Then, plan ETL tasks (will add records in a Firestore database):

--- a/README.md
+++ b/README.md
@@ -33,34 +33,27 @@ export END_TIMESTAMP=1687880000
 Then, plan ETL tasks (will add records in a Firestore database):
 
 ```
-python3 -m multiversxetl plan-tasks-with-intervals --indexer-url=${INDEXER_URL} \
-    --gcp-project-id=${GCP_PROJECT_ID}  --bq-dataset=${BQ_DATASET} \
+python3 -m multiversxetl plan-tasks-with-intervals --gcp-project-id=${GCP_PROJECT_ID} --group=${GROUP} \
+    --indexer-url=${INDEXER_URL} --bq-dataset=${BQ_DATASET} \
     --start-timestamp=${START_TIMESTAMP} --end-timestamp=${END_TIMESTAMP}
 
-python3 -m multiversxetl plan-tasks-without-intervals --indexer-url=${INDEXER_URL} \
-    --gcp-project-id=${GCP_PROJECT_ID}  --bq-dataset=${BQ_DATASET}
-```
-
-**Note:** in order to remove all previously planned tasks, run the following commands:
-
-```
-firebase firestore:delete --project=${GCP_PROJECT_ID} --recursive tasks_with_interval
-firebase firestore:delete --project=${GCP_PROJECT_ID} --recursive tasks_without_interval
+python3 -m multiversxetl plan-tasks-without-intervals --gcp-project-id=${GCP_PROJECT_ID} --group=${GROUP} \
+    --indexer-url=${INDEXER_URL} --bq-dataset=${BQ_DATASET}
 ```
 
 Inspect the tasks:
 
 ```
-python3 -m multiversxetl inspect-tasks --gcp-project-id=${GCP_PROJECT_ID}
+python3 -m multiversxetl inspect-tasks --group=${GROUP} --gcp-project-id=${GCP_PROJECT_ID}
 ```
 
 Then, extract and load the data on _worker_ machines:
 
 ```
-python3 -m multiversxetl extract-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --num-threads=4
-python3 -m multiversxetl extract-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --num-threads=4
-python3 -m multiversxetl load-with-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema --num-threads=4
-python3 -m multiversxetl load-without-intervals --workspace=${WORKSPACE} --gcp-project-id=${GCP_PROJECT_ID} --schema-folder=./schema --num-threads=4
+python3 -m multiversxetl extract-with-intervals --gcp-project-id=${GCP_PROJECT_ID} --workspace=${WORKSPACE} --group=${GROUP}  --num-threads=4
+python3 -m multiversxetl extract-without-intervals --gcp-project-id=${GCP_PROJECT_ID} --workspace=${WORKSPACE} --group=${GROUP} --num-threads=4
+python3 -m multiversxetl load-with-intervals --gcp-project-id=${GCP_PROJECT_ID} --workspace=${WORKSPACE} --group=${GROUP} --schema-folder=./schema --num-threads=4
+python3 -m multiversxetl load-without-intervals --gcp-project-id=${GCP_PROJECT_ID} --workspace=${WORKSPACE} --group=${GROUP} --schema-folder=./schema --num-threads=4
 ```
 
 From time to time, you may want to run `inspect-tasks` again to check the progress.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,6 @@ From time to time, you may want to run `inspect-tasks` again to check the progre
 
 Below are a few links useful for managing the ETL process. They are only accessible to the MultiversX team.
 
- - [Firestore dashboard](https://console.cloud.google.com/firestore/databases/-default-/data/panel?project=multiversx-blockchain-etl): inspect and manage the Firestore collections that store the metadata of the ETL tasks.
+ - [Firestore Dashboard](https://console.cloud.google.com/firestore/databases/-default-/data/panel?project=multiversx-blockchain-etl): inspect and manage the Firestore collections that store the metadata of the ETL tasks.
  - [BigQuery Workspace](https://console.cloud.google.com/bigquery?project=multiversx-blockchain-etl): inspect and manage the BigQuery datasets and tables.
  - [Analytics Hub](https://console.cloud.google.com/bigquery/analytics-hub/exchanges?project=multiversx-blockchain-etl): create and publish data listings.

--- a/multiversxetl/jobs/load_job.py
+++ b/multiversxetl/jobs/load_job.py
@@ -33,6 +33,8 @@ class LoadJob:
         self.file_storage = file_storage
         self.task = task
         self.schema_folder = schema_folder
+
+        # TODO: Possibly decouple from "bigquery.Client". Currently, constructor raises an exception when host machine is not authenticated to GCP.
         self.bigquery_client = bigquery.Client(project=gcp_project_id)
 
     def run(self) -> None:

--- a/multiversxetl/jobs/load_job_test.py
+++ b/multiversxetl/jobs/load_job_test.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 from google.cloud import bigquery
 
 from multiversxetl.jobs.load_job import (WRITE_DISPOSITION_APPEND,
@@ -17,6 +18,7 @@ class FileStorageMock:
         return Path(__file__).parent / f"transformed_{task_pretty_name}.json"
 
 
+@pytest.mark.integration
 def test_get_table_id():
     file_storage = FileStorageMock()
     task = Task("test", "", "test_index_name", "test_dataset", 0, 1)
@@ -25,6 +27,7 @@ def test_get_table_id():
     assert job._get_table_id() == "test_dataset.test_index_name"
 
 
+@pytest.mark.integration
 def test_prepare_job_config():
     file_storage = FileStorageMock()
 


### PR DESCRIPTION
 - Added a new (required) CLI parameter: `--group`: used as a prefix for Firestore collections, plus as a subfolder name within the workspace.
 - Adjusted (fixed) some CLI parameters - make them required, re-order them etc.
 - Updated readme.
 - Added Github Workflow to run tests.