### PR TITLE
Truncate table instead of delete. Fix some column descriptions

### DIFF
--- a/multiversxetl/bq_client.py
+++ b/multiversxetl/bq_client.py
@@ -28,8 +28,8 @@ class BqClient:
         for table in tables:
             logging.info(f"Truncating {bq_dataset}.{table}...")
 
-            table_ref = self.client.dataset(bq_dataset).table(table)
-            self.client.delete_table(table_ref, not_found_ok=True)
+            query = f"TRUNCATE TABLE `{bq_dataset}.{table}`"
+            self.run_query([], query)
 
     def delete_newer_than(self, bq_dataset: str, table: str, timestamp: int) -> None:
         logging.info(f"Deleting records in {bq_dataset}.{table} newer than {timestamp}...")

--- a/schema/accountsesdt.json
+++ b/schema/accountsesdt.json
@@ -12,12 +12,12 @@
     {
         "name": "balance",
         "type": "STRING",
-        "description": "The amount of ESDT token the address possesses. It includes the number of decimals."
+        "description": "The ESDT balance, in atomic units."
     },
     {
         "name": "balanceNum",
         "type": "FLOAT",
-        "description": "The amount of ESDT tokens the address possesses, in a numeric format."
+        "description": "See `balance`."
     },
     {
         "name": "currentOwner",

--- a/schema/operations.json
+++ b/schema/operations.json
@@ -134,13 +134,13 @@
         "name": "receivers",
         "mode": "REPEATED",
         "type": "STRING",
-        "description": "A list of receiver addresses in case of ESDTNFTTransfer or MultiESDTTransfer."
+        "description": "A list of receiver addresses (one element for now)."
     },
     {
         "name": "receiversShardIDs",
         "mode": "REPEATED",
         "type": "NUMERIC",
-        "description": "A list of receiver addresses shard IDs."
+        "description": "A list of receiver addresses shard IDs (one element for now)."
     },
     {
         "name": "receiverUserName",

--- a/schema/scresults.json
+++ b/schema/scresults.json
@@ -88,13 +88,13 @@
         "name": "receivers",
         "mode": "REPEATED",
         "type": "STRING",
-        "description": "A list of receiver addresses in case of ESDTNFTTransfer or MultiESDTTransfer."
+        "description": "A list of receiver addresses (one element for now)."
     },
     {
         "name": "receiversShardIDs",
         "mode": "REPEATED",
         "type": "NUMERIC",
-        "description": "A list of receiver addresses' shard IDs."
+        "description": "A list of receiver addresses' shard IDs (one element for now)."
     },
     {
         "name": "relayedValue",

--- a/schema/transactions.json
+++ b/schema/transactions.json
@@ -98,13 +98,13 @@
         "name": "receivers",
         "mode": "REPEATED",
         "type": "STRING",
-        "description": "A list of receiver addresses in case of ESDTNFTTransfer or MultiESDTTransfer."
+        "description": "A list of receiver addresses (one element for now)."
     },
     {
         "name": "receiversShardIDs",
         "mode": "REPEATED",
         "type": "NUMERIC",
-        "description": "A list of receiver addresses shard IDs."
+        "description": "A list of receiver addresses shard IDs (one element for now)."
     },
     {
         "name": "receiverUserName",

--- a/schema/validators.json
+++ b/schema/validators.json
@@ -2,7 +2,7 @@
     {
         "name": "_id",
         "type": "STRING",
-        "description": "A unique identifier (opaque)."
+        "description": "A unique identifier (somehow opaque). Composed as `{shard}_{epoch}`."
     },
     {
         "name": "publicKeys",


### PR DESCRIPTION
 - Use `TRUNCATE TABLE` to delete items from tables associated with mutable ES indices. Truncation retains metadata (such as column descriptions).
 - Fix after review for: https://github.com/multiversx/multiversx-etl/pull/25.