### PR TITLE
Counts errata & indexer credentials

### DIFF
--- a/multiversxetl/app.py
+++ b/multiversxetl/app.py
@@ -124,21 +124,23 @@ def _do_find_latest_good_checkpoint(args: Any):
     controller = AppController(workspace)
     search_step = args.search_step
 
-    start_timestamp = controller.worker_config.append_only_indices.time_partition_start
+    indices_config = controller.worker_config.append_only_indices
+    start_timestamp = indices_config.time_partition_start
     now = int(_get_now().timestamp())
 
     for end_timestamp in range(now, start_timestamp, -search_step):
         try:
             check_loaded_data(
                 bq_client=controller.bq_client,
-                bq_dataset=controller.worker_config.append_only_indices.bq_dataset,
+                bq_dataset=indices_config.bq_dataset,
                 indexer=controller.indexer,
-                tables=controller.worker_config.append_only_indices.indices,
+                tables=indices_config.indices,
                 start_timestamp=start_timestamp,
                 end_timestamp=end_timestamp,
                 use_global_counts_for_bq=False,
                 should_fail_on_counts_mismatch=True,
                 skip_counts_check_for_indices=[],
+                counts_checks_erratum=indices_config.counts_checks_erratum
             )
 
             logging.info(f"Latest good checkpoint: {end_timestamp}")

--- a/multiversxetl/app.py
+++ b/multiversxetl/app.py
@@ -140,7 +140,7 @@ def _do_find_latest_good_checkpoint(args: Any):
                 use_global_counts_for_bq=False,
                 should_fail_on_counts_mismatch=True,
                 skip_counts_check_for_indices=[],
-                counts_checks_erratum=indices_config.counts_checks_erratum
+                counts_checks_errata=indices_config.counts_checks_errata
             )
 
             logging.info(f"Latest good checkpoint: {end_timestamp}")

--- a/multiversxetl/app_controller.py
+++ b/multiversxetl/app_controller.py
@@ -35,7 +35,13 @@ class AppController:
         worker_id = socket.gethostname()
 
         self.bq_client = BqClient(self.worker_config.gcp_project_id)
-        self.indexer = Indexer(self.worker_config.indexer_url)
+
+        self.indexer = Indexer(
+            url=self.worker_config.indexer_url,
+            username=self.worker_config.indexer_username,
+            password=self.worker_config.indexer_password
+        )
+
         self.cloud_logger = CloudLogger(self.worker_config.gcp_project_id, worker_id)
         self.tasks_dashboard = TasksDashboard()
         file_storage = FileStorage(workspace)

--- a/multiversxetl/app_controller.py
+++ b/multiversxetl/app_controller.py
@@ -148,7 +148,7 @@ class AppController:
             use_global_counts_for_bq=use_global_counts_for_bq_when_checking_loaded_data,
             should_fail_on_counts_mismatch=indices_config.should_fail_on_counts_mismatch,
             skip_counts_check_for_indices=indices_config.skip_counts_check_for_indices,
-            counts_checks_erratum=indices_config.counts_checks_erratum
+            counts_checks_errata=indices_config.counts_checks_errata
         )
 
         return latest_planned_interval_end_time
@@ -216,7 +216,7 @@ class AppController:
             use_global_counts_for_bq=False,
             should_fail_on_counts_mismatch=True,
             skip_counts_check_for_indices=[],
-            counts_checks_erratum=indices_config.counts_checks_erratum
+            counts_checks_errata=indices_config.counts_checks_errata
         )
 
 

--- a/multiversxetl/app_controller.py
+++ b/multiversxetl/app_controller.py
@@ -141,7 +141,8 @@ class AppController:
             end_timestamp=latest_planned_interval_end_time,
             use_global_counts_for_bq=use_global_counts_for_bq_when_checking_loaded_data,
             should_fail_on_counts_mismatch=indices_config.should_fail_on_counts_mismatch,
-            skip_counts_check_for_indices=indices_config.skip_counts_check_for_indices
+            skip_counts_check_for_indices=indices_config.skip_counts_check_for_indices,
+            counts_checks_erratum=indices_config.counts_checks_erratum
         )
 
         return latest_planned_interval_end_time
@@ -189,8 +190,9 @@ class AppController:
         """
         From the BQ tables corresponding to append-only indices, deletes records newer than the latest checkpoint.
         """
-        bq_dataset = self.worker_config.append_only_indices.bq_dataset
-        indices = self.worker_config.append_only_indices.indices
+        indices_config = self.worker_config.append_only_indices
+        bq_dataset = indices_config.bq_dataset
+        indices = indices_config.indices
         checkpoint_timestamp = self.worker_state.latest_checkpoint_timestamp
 
         logging.info(f"Rewinding to checkpoint {checkpoint_timestamp}...")
@@ -203,11 +205,12 @@ class AppController:
             bq_dataset=bq_dataset,
             indexer=self.indexer,
             tables=indices,
-            start_timestamp=self.worker_config.append_only_indices.time_partition_start,
+            start_timestamp=indices_config.time_partition_start,
             end_timestamp=checkpoint_timestamp,
             use_global_counts_for_bq=False,
             should_fail_on_counts_mismatch=True,
-            skip_counts_check_for_indices=[]
+            skip_counts_check_for_indices=[],
+            counts_checks_erratum=indices_config.counts_checks_erratum
         )
 
 

--- a/multiversxetl/checks.py
+++ b/multiversxetl/checks.py
@@ -79,6 +79,11 @@ def _do_check_loaded_data_for_table(
     if not should_fail_on_counts_mismatch:
         return
 
+    erratum = counts_checks_erratum.get_erratum(table)
+    if erratum:
+        counts_delta += erratum
+        logging.warning(f"Applied counts erratum for table '{table}': {erratum}. New delta = {counts_delta}.")
+
     if counts_delta > 0:
         raise CountsMismatchError(f"Data is missing in BigQuery for table '{table}'. Delta = {counts_delta}.")
 

--- a/multiversxetl/checks.py
+++ b/multiversxetl/checks.py
@@ -5,7 +5,7 @@ from typing import Any, List, Optional, Protocol
 from google.cloud import bigquery
 
 from multiversxetl.errors import CountsMismatchError
-from multiversxetl.worker_config import CountChecksErratum
+from multiversxetl.worker_config import CountChecksErrata
 
 
 class IIndexer(Protocol):
@@ -28,7 +28,7 @@ def check_loaded_data(
     use_global_counts_for_bq: bool,
     should_fail_on_counts_mismatch: bool,
     skip_counts_check_for_indices: List[str],
-    counts_checks_erratum: CountChecksErratum
+    counts_checks_errata: CountChecksErrata
 ):
     for table in tables:
         if table in skip_counts_check_for_indices:
@@ -43,7 +43,7 @@ def check_loaded_data(
             end_timestamp,
             use_global_counts_for_bq,
             should_fail_on_counts_mismatch,
-            counts_checks_erratum
+            counts_checks_errata
         )
 
 
@@ -56,7 +56,7 @@ def _do_check_loaded_data_for_table(
         end_timestamp: int,
         use_global_counts_for_bq: bool,
         should_fail_on_counts_mismatch: bool,
-        counts_checks_erratum: CountChecksErratum
+        counts_checks_errata: CountChecksErrata
 ):
     start_datetime = datetime.datetime.fromtimestamp(start_timestamp, tz=datetime.timezone.utc)
     end_datetime = datetime.datetime.fromtimestamp(end_timestamp, tz=datetime.timezone.utc)
@@ -79,7 +79,7 @@ def _do_check_loaded_data_for_table(
     if not should_fail_on_counts_mismatch:
         return
 
-    erratum = counts_checks_erratum.get_erratum(table)
+    erratum = counts_checks_errata.get_erratum(table)
     if erratum:
         counts_delta += erratum
         logging.warning(f"Applied counts erratum for table '{table}': {erratum}. New delta = {counts_delta}.")

--- a/multiversxetl/checks.py
+++ b/multiversxetl/checks.py
@@ -5,6 +5,7 @@ from typing import Any, List, Optional, Protocol
 from google.cloud import bigquery
 
 from multiversxetl.errors import CountsMismatchError
+from multiversxetl.worker_config import CountChecksErratum
 
 
 class IIndexer(Protocol):
@@ -26,7 +27,8 @@ def check_loaded_data(
     end_timestamp: int,
     use_global_counts_for_bq: bool,
     should_fail_on_counts_mismatch: bool,
-    skip_counts_check_for_indices: List[str]
+    skip_counts_check_for_indices: List[str],
+    counts_checks_erratum: CountChecksErratum
 ):
     for table in tables:
         if table in skip_counts_check_for_indices:
@@ -40,7 +42,8 @@ def check_loaded_data(
             start_timestamp,
             end_timestamp,
             use_global_counts_for_bq,
-            should_fail_on_counts_mismatch
+            should_fail_on_counts_mismatch,
+            counts_checks_erratum
         )
 
 
@@ -52,7 +55,8 @@ def _do_check_loaded_data_for_table(
         start_timestamp: int,
         end_timestamp: int,
         use_global_counts_for_bq: bool,
-        should_fail_on_counts_mismatch: bool
+        should_fail_on_counts_mismatch: bool,
+        counts_checks_erratum: CountChecksErratum
 ):
     start_datetime = datetime.datetime.fromtimestamp(start_timestamp, tz=datetime.timezone.utc)
     end_datetime = datetime.datetime.fromtimestamp(end_timestamp, tz=datetime.timezone.utc)

--- a/multiversxetl/config/worker_config_mainnet.json
+++ b/multiversxetl/config/worker_config_mainnet.json
@@ -24,7 +24,7 @@
         "num_intervals_in_bulk": 1,
         "num_threads": 4,
         "should_fail_on_counts_mismatch": true,
-        "counts_checks_erratum": {
+        "counts_checks_errata": {
             "accountsesdthistory": -20,
             "accountshistory": 145,
             "blocks": -7,

--- a/multiversxetl/config/worker_config_mainnet.json
+++ b/multiversxetl/config/worker_config_mainnet.json
@@ -23,7 +23,19 @@
         "interval_size_in_seconds": 86400,
         "num_intervals_in_bulk": 1,
         "num_threads": 4,
-        "should_fail_on_counts_mismatch": true
+        "should_fail_on_counts_mismatch": true,
+        "counts_checks_erratum": {
+            "accountsesdthistory": -20,
+            "accountshistory": 145,
+            "blocks": -7,
+            "logs": -12619,
+            "miniblocks": -53193,
+            "operations": -1,
+            "receipts": 0,
+            "rounds": 0,
+            "scresults": 8,
+            "transactions": -4
+        }
     },
     "mutable_indices": {
         "bq_dataset": "mainnet_mutable_indices_staging",

--- a/multiversxetl/indexer.py
+++ b/multiversxetl/indexer.py
@@ -11,7 +11,9 @@ SCAN_BATCH_SIZE = 7500
 
 
 class Indexer:
-    def __init__(self, url: str, basic_auth: Optional[Tuple[str, str]] = None):
+    def __init__(self, url: str, username: str = "", password: str = ""):
+        basic_auth = (username, password) if username and password else None
+
         self.elastic_search_client = Elasticsearch(
             url,
             max_retries=ELASTICSEARCH_MAX_RETRIES,

--- a/multiversxetl/worker_config.py
+++ b/multiversxetl/worker_config.py
@@ -9,6 +9,8 @@ class WorkerConfig:
             gcp_project_id: str,
             schema_folder: Path,
             indexer_url: str,
+            indexer_username: str,
+            indexer_password: str,
             genesis_timestamp: int,
             append_only_indices: 'IndicesConfig',
             mutable_indices: 'IndicesConfig'
@@ -16,6 +18,8 @@ class WorkerConfig:
         self.gcp_project_id = gcp_project_id
         self.schema_folder = schema_folder
         self.indexer_url = indexer_url
+        self.indexer_username = indexer_username
+        self.indexer_password = indexer_password
         self.genesis_timestamp = genesis_timestamp
         self.append_only_indices = append_only_indices
         self.mutable_indices = mutable_indices
@@ -31,6 +35,8 @@ class WorkerConfig:
             gcp_project_id=data["gcp_project_id"],
             schema_folder=Path(data["schema_folder"]),
             indexer_url=data["indexer_url"],
+            indexer_username=data.get("indexer_username", ""),
+            indexer_password=data.get("indexer_password", ""),
             genesis_timestamp=data["genesis_timestamp"],
             append_only_indices=IndicesConfig.load_from_dict(data["append_only_indices"]),
             mutable_indices=IndicesConfig.load_from_dict(data["mutable_indices"])

--- a/multiversxetl/worker_config.py
+++ b/multiversxetl/worker_config.py
@@ -57,7 +57,7 @@ class IndicesConfig:
             num_threads: int,
             should_fail_on_counts_mismatch: bool,
             skip_counts_check_for_indices: List[str],
-            counts_checks_erratum: "CountChecksErratum"
+            counts_checks_errata: "CountChecksErrata"
     ) -> None:
         self.bq_dataset = bq_dataset
         self.bq_data_transfer_name = bq_data_transfer_name
@@ -70,7 +70,7 @@ class IndicesConfig:
         self.num_threads = num_threads
         self.should_fail_on_counts_mismatch = should_fail_on_counts_mismatch
         self.skip_counts_check_for_indices = skip_counts_check_for_indices
-        self.counts_checks_erratum = counts_checks_erratum
+        self.counts_checks_errata = counts_checks_errata
 
     @classmethod
     def load_from_dict(cls, data: Dict[str, Any]) -> "IndicesConfig":
@@ -86,16 +86,16 @@ class IndicesConfig:
             num_threads=data["num_threads"],
             should_fail_on_counts_mismatch=data["should_fail_on_counts_mismatch"],
             skip_counts_check_for_indices=data.get("skip_counts_check_for_indices", []),
-            counts_checks_erratum=CountChecksErratum.load_from_dict(data.get("counts_checks_erratum", {}))
+            counts_checks_errata=CountChecksErrata.load_from_dict(data.get("counts_checks_errata", {}))
         )
 
 
-class CountChecksErratum:
+class CountChecksErrata:
     def __init__(self, data: Dict[str, int]) -> None:
         self.data: Dict[str, int] = data
 
     @classmethod
-    def load_from_dict(cls, data: Dict[str, Any]) -> "CountChecksErratum":
+    def load_from_dict(cls, data: Dict[str, Any]) -> "CountChecksErrata":
         return cls(
             data=data
         )

--- a/multiversxetl/worker_config.py
+++ b/multiversxetl/worker_config.py
@@ -50,7 +50,8 @@ class IndicesConfig:
             num_intervals_in_bulk: int,
             num_threads: int,
             should_fail_on_counts_mismatch: bool,
-            skip_counts_check_for_indices: List[str] = []
+            skip_counts_check_for_indices: List[str],
+            counts_checks_erratum: "CountChecksErratum"
     ) -> None:
         self.bq_dataset = bq_dataset
         self.bq_data_transfer_name = bq_data_transfer_name
@@ -63,6 +64,7 @@ class IndicesConfig:
         self.num_threads = num_threads
         self.should_fail_on_counts_mismatch = should_fail_on_counts_mismatch
         self.skip_counts_check_for_indices = skip_counts_check_for_indices
+        self.counts_checks_erratum = counts_checks_erratum
 
     @classmethod
     def load_from_dict(cls, data: Dict[str, Any]) -> "IndicesConfig":
@@ -77,5 +79,20 @@ class IndicesConfig:
             num_intervals_in_bulk=data["num_intervals_in_bulk"],
             num_threads=data["num_threads"],
             should_fail_on_counts_mismatch=data["should_fail_on_counts_mismatch"],
-            skip_counts_check_for_indices=data.get("skip_counts_check_for_indices", [])
+            skip_counts_check_for_indices=data.get("skip_counts_check_for_indices", []),
+            counts_checks_erratum=CountChecksErratum.load_from_dict(data.get("counts_checks_erratum", {}))
         )
+
+
+class CountChecksErratum:
+    def __init__(self, data: Dict[str, int]) -> None:
+        self.data: Dict[str, int] = data
+
+    @classmethod
+    def load_from_dict(cls, data: Dict[str, Any]) -> "CountChecksErratum":
+        return cls(
+            data=data
+        )
+
+    def get_erratum(self, table: str) -> int:
+        return self.data.get(table, 0)


### PR DESCRIPTION
Related to: https://github.com/multiversx/multiversx-etl/issues/34.

We've switched to a fetching data from the new public ES instance. However, there are some minor discrepancies between the previously-used ES instance and the new one. To account for this, when performing the counts checks, we are applying an erratum for each index / table. In the future, we'll do a full re-import (from genesis) from the new ES instance.

Additionally, added support for ES credentials.