### PR TITLE
Update schemas with new "uuid" and "epoch" fields

### DIFF
--- a/schema/blocks.json
+++ b/schema/blocks.json
@@ -386,5 +386,10 @@
         "name": "chainID",
         "type": "STRING",
         "description": "The chain ID."
+    },
+    {
+        "name": "uuid",
+        "type": "STRING",
+        "description": "Unique identifier used for ES queries."
     }
 ]

--- a/schema/logs.json
+++ b/schema/logs.json
@@ -58,5 +58,10 @@
         "name": "timestamp",
         "type": "TIMESTAMP",
         "description": "The timestamp of the block in which the log was generated."
+    },
+    {
+        "name": "uuid",
+        "type": "STRING",
+        "description": "Unique identifier used for ES queries."
     }
 ]

--- a/schema/operations.json
+++ b/schema/operations.json
@@ -268,5 +268,15 @@
         "name": "hadRefund",
         "type": "BOOLEAN",
         "description": "Whether the transaction has a refund."
+    },
+    {
+        "name": "epoch",
+        "type": "NUMERIC",
+        "description": "The epoch the operation belongs to."
+    },
+    {
+        "name": "uuid",
+        "type": "STRING",
+        "description": "Unique identifier used for ES queries."
     }
 ]

--- a/schema/scresults.json
+++ b/schema/scresults.json
@@ -153,5 +153,15 @@
         "mode": "REPEATED",
         "type": "FLOAT",
         "description": "See `esdtValues` field."
+    },
+    {
+        "name": "epoch",
+        "type": "NUMERIC",
+        "description": "The epoch the scresult belongs to."
+    },
+    {
+        "name": "uuid",
+        "type": "STRING",
+        "description": "Unique identifier used for ES queries."
     }
 ]

--- a/schema/transactions.json
+++ b/schema/transactions.json
@@ -218,5 +218,15 @@
         "name": "hadRefund",
         "type": "BOOLEAN",
         "description": "Whether the transaction has a refund."
+    },
+    {
+        "name": "epoch",
+        "type": "NUMERIC",
+        "description": "The epoch the transaction belongs to."
+    },
+    {
+        "name": "uuid",
+        "type": "STRING",
+        "description": "Unique identifier used for ES queries."
     }
 ]


### PR DESCRIPTION
The updates are related to these changes:
- https://github.com/multiversx/mx-chain-es-indexer-go/pull/322
- https://github.com/multiversx/mx-chain-es-indexer-go/pull/323